### PR TITLE
V1 cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ target_link_libraries(bonxai_map
 )
 
 # ====================================================
+# ====================================================
+
+# ====================================================
 
 # ====================================================
 include_directories(
@@ -72,6 +75,7 @@ add_executable(rolling_map_node
   src/chunk_manager.cpp
   src/rolling_map.cpp
   src/rolling_map_node.cpp
+  src/utils.cpp
 )
 
 target_include_directories(rolling_map_node PUBLIC

--- a/include/rolling_map/chunk_manager.h
+++ b/include/rolling_map/chunk_manager.h
@@ -1,9 +1,9 @@
-#ifndef CHUNK_MANAGER_H
-#define CHUNK_MANAGER_H
+#ifndef ROLLING_MAP__CHUNK_MANAGER_H
+#define ROLLING_MAP__CHUNK_MANAGER_H
 #include "rclcpp/rclcpp.hpp"
 
 #include "bonxai_map/occupancy_map.hpp"
-#include "rolling_map/rolling_map_params.h"
+#include "rolling_map/map_params.h"
 #include "bonxai_core/serialization.hpp"
 
 #include <pcl/point_cloud.h>
@@ -421,4 +421,4 @@ namespace RM
     };
 }
 
-#endif // CHUNK_MANAGER_H
+#endif // ROLLING_MAP__CHUNK_MANAGER_H

--- a/include/rolling_map/chunk_manager.h
+++ b/include/rolling_map/chunk_manager.h
@@ -2,9 +2,10 @@
 #define ROLLING_MAP__CHUNK_MANAGER_H
 #include "rclcpp/rclcpp.hpp"
 
+#include "bonxai_core/serialization.hpp"
 #include "bonxai_map/occupancy_map.hpp"
 #include "rolling_map/map_params.h"
-#include "bonxai_core/serialization.hpp"
+#include "rolling_map/utils.h"
 
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -368,56 +369,6 @@ namespace RM
 
         //Write thread
         std::thread write_thread_;
-
-        ///////////////////
-        ////Conversion/////
-        ///////////////////
-        /**
-         * @brief Converts a 3D point in map frame to a voxel coord. Exactly the same as Bonxai::posToCoord
-         * @param PCLPoint& point
-         * @return Bonxai::CoordT
-         */
-        Bonxai::CoordT mapPointToVoxelCoord(const PCLPoint& point);
-
-        /**
-         * @brief Converts a voxel coord to a 3D point in map frame. Exactly the same as Bonxai::coordToPos
-         * @param Bonxai::CoordT& coord
-         * @return PCLPoint
-         */
-        PCLPoint voxelCoordToMapPoint(const Bonxai::CoordT& coord);
-
-        /**
-         * @brief Convert a voxel coord to a 3D point in the map frame to the center of the voxel
-         * @param Bonxai::CoordT& coord
-         * @return PCLPoint
-         */
-        PCLPoint voxelCoordToMapCenterPoint(const Bonxai::CoordT& coord);
-
-        /**
-         * @brief COnverts a voxel coord to a chunk coordinate
-         * @param Bonxai::CoordT& coord
-         * @return CoordT
-         */
-        Bonxai::CoordT voxelCoordToChunkCoord(const Bonxai::CoordT& coord);
-
-        /**
-         * @brief Maps a chunk coordinate to the voxel coordinate, which is the back right down voxel in the map frame
-         * @param const Bonxai::CoordT& coord
-         * @return Bonxai::CoordT
-         */
-        Bonxai::CoordT chunkCoordToVoxelCoord(const Bonxai::CoordT& coord);
-
-        /**
-         * @brief Maps a 3D point in the map frame to a voxel coordinate that is relative to the voxel origin of the chunk
-         * @param const PCLPoint& point
-         * @return Bonxai::CoordT
-         */
-        Bonxai::CoordT mapFramePointToChunkFrameCoord(const PCLPoint& mP);
-        
-        /**
-         * Maps a 3D point from map frame into chunk frame
-         */
-        PCLPoint mapFramePointToChunkFramePoint(const PCLPoint& mp);
     };
 }
 

--- a/include/rolling_map/chunk_manager.h
+++ b/include/rolling_map/chunk_manager.h
@@ -138,6 +138,15 @@ namespace RM
             UNSET = 2
         };
 
+        //Chunk Metadata
+        struct Chunkmd
+        {
+            Bonxai::CoordT coord {0,0,0};
+            ChunkKey key {"_"};
+            ChunkState state {ChunkState::UNSET};
+            bool touched_once {false};
+        };
+
         /**
          * @brief Set the center coord
          * @param Bonxai::CoordT& source
@@ -334,12 +343,12 @@ namespace RM
         //Data Structures
         /////////////////
 
+        const size_t CACHE_SIZE {27};
+
         //27 sized fixed array of map pointers
         std::array<MapPtr,27> chunks_;
-        //27 sized fixed array of booleans indicating if the chunk is clean
-        std::array<std::pair<ChunkKey,ChunkState>,27> chunk_states_;
-        //Boolean values to track if a chunk was touched atleast once during a particular update. It is reset every update
-        std::array<bool,27> touched_once_;
+        //27 sized fixed array of chunk metadata structs
+        std::array<Chunkmd,27> chunks_metadata_;
         //The center coordinate
         Bonxai::CoordT current_source_coord_;
         //Flag to check if the first map has been initted

--- a/include/rolling_map/map_manager.h
+++ b/include/rolling_map/map_manager.h
@@ -6,6 +6,7 @@
 #include "bonxai_map/occupancy_map.hpp"
 #include "rolling_map/chunk_manager.h"
 #include "rolling_map/map_params.h"
+#include "rolling_map/utils.h"
 
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -59,76 +60,6 @@ namespace RM
         void getOccupiedVoxels(PCLPointCloud& points);
 
     private:
-
-        /////////////////////////
-        //////Chunk Neibors//////
-        /////////////////////////
-
-        /**
-         * @brief Get the 6 face neibors of a chunk
-         * @param Bonxai::CoordT& c
-         * @return std::vector<Bonxai::CoordT>
-         */
-        std::array<Bonxai::CoordT,6> getFaceNeibors(const Bonxai::CoordT& coord);
-
-        /**
-         * @brief Get the 12 edge neibors of a chunk
-         * @param Bonxai::CoordT& c
-         * @return std::vector<Bonxai::CoordT>
-         */
-        std::array<Bonxai::CoordT,12> getEdgeNeibors(const Bonxai::CoordT& coord);
-
-        /**
-         * @brief Get the 8 corner neibors of a chunk
-         * @param Bonxai::CoordT& c
-         * @return std::vector<Bonxai::CoordT>
-         */
-        std::array<Bonxai::CoordT,8> getCornerNeibors(const Bonxai::CoordT& coord);
-
-        /////////////////////////
-        //////Conversions////////
-        /////////////////////////
-        /**
-         * @brief Converts a 3D point in map frame to a voxel coord. Exactly the same as Bonxai::posToCoord
-         * @param PCLPoint& point
-         * @return Bonxai::CoordT
-         */
-        Bonxai::CoordT mapPointToVoxelCoord(const PCLPoint& point);
-
-        /**
-         * @brief Converts a voxel coord to a 3D point in map frame. Exactly the same as Bonxai::coordToPos
-         * @param Bonxai::CoordT& coord
-         * @return PCLPoint
-         */
-        PCLPoint voxelCoordToMapPoint(const Bonxai::CoordT& coord);
-
-        /**
-         * @brief Convert a voxel coord to a 3D point in the map frame to the center of the voxel
-         * @param Bonxai::CoordT& coord
-         * @return PCLPoint
-         */
-        PCLPoint voxelCoordToMapCenterPoint(const Bonxai::CoordT& coord);
-
-        /**
-         * @brief COnverts a voxel coord to a chunk coordinate
-         * @param Bonxai::CoordT& coord
-         * @return CoordT
-         */
-        Bonxai::CoordT voxelCoordToChunkCoord(const Bonxai::CoordT& coord);
-
-        /**
-         * @brief Maps a chunk coordinate to the voxel coordinate, which is the back right down voxel in the map frame
-         * @param const Bonxai::CoordT& coord
-         * @return Bonxai::CoordT
-         */
-        Bonxai::CoordT chunkCoordToVoxelCoord(const Bonxai::CoordT& coord);
-
-        /**
-         * @brief Maps a 3D point in the map frame to a voxel coordinate that is relative to the voxel origin of the chunk
-         * @param const PCLPoint& point
-         * @return Bonxai::CoordT
-         */
-        Bonxai::CoordT mapFramePointToChunkFrameCoord(const PCLPoint& mP);
 
         //Chunk Manager
         std::unique_ptr<ChunkManager> chunk_manager_ {nullptr};

--- a/include/rolling_map/map_manager.h
+++ b/include/rolling_map/map_manager.h
@@ -1,11 +1,11 @@
-#ifndef MAP_MANAGER_H
-#define MAP_MANAGER_H
+#ifndef ROLLING_MAP__MAP_MANAGER_H
+#define ROLLING_MAP__MAP_MANAGER_H
 
 #include "rclcpp/rclcpp.hpp"
 
 #include "bonxai_map/occupancy_map.hpp"
 #include "rolling_map/chunk_manager.h"
-#include "rolling_map/rolling_map_params.h"
+#include "rolling_map/map_params.h"
 
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -145,4 +145,4 @@ namespace RM
     };
 
 } //namespace RM
-#endif // MAP_MANAGER_H
+#endif // ROLLING_MAP__MAP_MANAGER_H

--- a/include/rolling_map/map_params.h
+++ b/include/rolling_map/map_params.h
@@ -1,5 +1,5 @@
-#ifndef ROLLING_MAP_PARAMS_H
-#define ROLLING_MAP_PARAMS_H
+#ifndef ROLLING_MAP__PARAMS_H
+#define ROLLING_MAP__PARAMS_H
 #include <string>
 /*
 A collection of data structs to
@@ -38,4 +38,4 @@ struct ChunkParams
     std::string chunk_folder_path {"chunk_folder"}; //path to the chunk folder
 };
 }
-#endif //ROLLING_MAP_PARAMS_H
+#endif //ROLLING_MAP__PARAMS_H

--- a/include/rolling_map/map_server.h
+++ b/include/rolling_map/map_server.h
@@ -1,5 +1,5 @@
-#ifndef ROLLING_MAP_H
-#define ROLLING_MAP_H
+#ifndef ROLLING_MAP__MAP_SERVER_H
+#define ROLLING_MAP__MAP_SERVER_H
 
 #include <pcl/common/transforms.h>
 #include <pcl/filters/statistical_outlier_removal.h>
@@ -17,7 +17,7 @@
 #include "tf2_eigen/tf2_eigen.hpp"
 #include "message_filters/subscriber.h"
 
-#include "rolling_map/rolling_map_params.h"
+#include "rolling_map/map_params.h"
 #include "rolling_map/map_manager.h"
 
 #include <mutex>
@@ -102,4 +102,4 @@ private:
     PCLPointCloud free_voxels_;
 };
 }
-#endif //ROLLING_MAP_H
+#endif //ROLLING_MAP__ROLLING_MAP

--- a/include/rolling_map/rolling_map.h
+++ b/include/rolling_map/rolling_map.h
@@ -61,9 +61,6 @@ private:
      */
     void cloudCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
 
-
-    void publishMap();
-
     //Map Manager
     MapManager map_manager_;
 

--- a/include/rolling_map/utils.h
+++ b/include/rolling_map/utils.h
@@ -23,67 +23,21 @@ namespace RM
          * @param Bonxai::CoordT& c
          * @return std::array<Bonxai::CoordT,6>
          */
-        std::array<Bonxai::CoordT,6> getFaceNeibors(const Bonxai::CoordT& coord)
-        {
-            //Follow the right-handle rule system X(front),Y(Left), Z(Up)
-            return {{
-                {coord.x + 1, coord.y, coord.z}, //front
-                {coord.x - 1, coord.y, coord.z}, //back
-                {coord.x, coord.y + 1, coord.z}, //left
-                {coord.x, coord.y - 1, coord.z}, //right
-                {coord.x, coord.y, coord.z + 1}, //top
-                {coord.x, coord.y, coord.z - 1}  //down
-            }};
-        }
+        std::array<Bonxai::CoordT,6> getFaceNeibors(const Bonxai::CoordT& coord);
 
         /**
          * @brief Get the 12 edge neibors of a chunk
          * @param Bonxai::CoordT& c
          * @return std::array<Bonxai::CoordT,12>
          */
-        std::array<Bonxai::CoordT,12> getEdgeNeibors(const Bonxai::CoordT& coord)
-        {
-            //Follow the right-handle rule system X(front),Y(Left), Z(Up)
-            return {{
-                // xy-plane edges
-                {coord.x - 1, coord.y - 1, coord.z}, //back-right
-                {coord.x - 1, coord.y + 1, coord.z}, //back-left
-                {coord.x + 1, coord.y - 1, coord.z}, //front-right
-                {coord.x + 1, coord.y + 1, coord.z}, //front-left
-
-                // xz-plane edges
-                {coord.x - 1, coord.y, coord.z - 1}, //back-down
-                {coord.x - 1, coord.y, coord.z + 1}, //back-top
-                {coord.x + 1, coord.y, coord.z - 1}, //front-down
-                {coord.x + 1, coord.y, coord.z + 1}, //front-top
-
-                // yz-plane edges
-                {coord.x, coord.y - 1, coord.z - 1}, //right-down
-                {coord.x, coord.y - 1, coord.z + 1}, //right-top
-                {coord.x, coord.y + 1, coord.z - 1}, //left-down
-                {coord.x, coord.y + 1, coord.z + 1}  //left-top
-            }};
-        }
+        std::array<Bonxai::CoordT,12> getEdgeNeibors(const Bonxai::CoordT& coord);
 
         /**
          * @brief Get the 8 corner neibors of a chunk
          * @param Bonxai::CoordT& c
          * @return std::array<Bonxai::CoordT,8>
          */
-        std::array<Bonxai::CoordT,8> getCornerNeibors(const Bonxai::CoordT& coord)
-        {
-            //Follow the right-handle rule system X(front),Y(Left), Z(Up)
-            return {{
-                {coord.x - 1, coord.y - 1, coord.z - 1}, //back  - right  -  down
-                {coord.x - 1, coord.y - 1, coord.z + 1}, //back  - right  -  top
-                {coord.x - 1, coord.y + 1, coord.z - 1}, //back  - left   -  down
-                {coord.x - 1, coord.y + 1, coord.z + 1}, //back  - left  -   top
-                {coord.x + 1, coord.y - 1, coord.z - 1}, //front - right  -  down
-                {coord.x + 1, coord.y - 1, coord.z + 1}, //front - right  -  top
-                {coord.x + 1, coord.y + 1, coord.z - 1}, //front - left   -  down
-                {coord.x + 1, coord.y + 1, coord.z + 1}  //front - left   -  top
-            }};
-        }
+        std::array<Bonxai::CoordT,8> getCornerNeibors(const Bonxai::CoordT& coord);
 
         /**
          * @brief Converts a 3D point in map frame to a voxel coord. Exactly the same as Bonxai::posToCoord
@@ -91,14 +45,7 @@ namespace RM
          * param double resolution
          * @return Bonxai::CoordT
          */
-        Bonxai::CoordT mapPointToVoxelCoord(const PCLPoint& point,double resolution)
-        {
-            double inv_resolution = 1.0 / resolution;
-            return {
-                static_cast<int32_t>(std::floor(point.x * inv_resolution)),
-                static_cast<int32_t>(std::floor(point.y * inv_resolution)),
-                static_cast<int32_t>(std::floor(point.z * inv_resolution))};
-        }
+        Bonxai::CoordT mapPointToVoxelCoord(const PCLPoint& point,double resolution);
 
         /**
          * @brief Converts a voxel coord to a 3D point in map frame. Exactly the same as Bonxai::coordToPos
@@ -106,15 +53,7 @@ namespace RM
          * param double resolution
          * @return PCLPoint
          */
-        PCLPoint voxelCoordToMapPoint(const Bonxai::CoordT& coord,double resolution)
-        {
-            return 
-            {
-            (static_cast<double>(coord.x)) * resolution,
-            (static_cast<double>(coord.y)) * resolution,
-            (static_cast<double>(coord.z)) * resolution};
-
-        }
+        PCLPoint voxelCoordToMapPoint(const Bonxai::CoordT& coord,double resolution);
 
         /**
          * @brief Convert a voxel coord to a 3D point in the map frame to the center of the voxel
@@ -122,14 +61,7 @@ namespace RM
          * @param double resolution
          * @return PCLPoint
          */
-        PCLPoint voxelCoordToMapCenterPoint(const Bonxai::CoordT& coord, double resolution)
-        {
-            double half = 0.5 * resolution;
-            return {
-            (static_cast<double>(coord.x)) * resolution + half,
-            (static_cast<double>(coord.y)) * resolution + half,
-            (static_cast<double>(coord.z)) * resolution + half};
-        }
+        PCLPoint voxelCoordToMapCenterPoint(const Bonxai::CoordT& coord, double resolution);
 
         /**
          * @brief COnverts a voxel coord to a chunk coordinate
@@ -137,16 +69,7 @@ namespace RM
          * @param int32_t chunk_dim. The resolution of a chunk in terms of voxels
          * @return CoordT
          */
-        Bonxai::CoordT voxelCoordToChunkCoord(const Bonxai::CoordT& coord,int32_t chunk_dim)
-        {
-
-            return {
-            coord.x >= 0 ? coord.x / chunk_dim : (coord.x - chunk_dim + 1) / chunk_dim,
-            coord.y >= 0 ? coord.y / chunk_dim : (coord.y - chunk_dim + 1) / chunk_dim,
-            coord.z >= 0 ? coord.z / chunk_dim : (coord.z - chunk_dim + 1) / chunk_dim
-            };
-
-        }
+        Bonxai::CoordT voxelCoordToChunkCoord(const Bonxai::CoordT& coord,int32_t chunk_dim);
 
         /**
          * @brief Maps a chunk coordinate to the voxel coordinate, which is the back right down voxel in the map frame
@@ -154,15 +77,7 @@ namespace RM
          * @param int32_t chunk_dim. The resolution of a chunk in terms of voxels
          * @return Bonxai::CoordT
          */
-        Bonxai::CoordT chunkCoordToVoxelCoord(const Bonxai::CoordT& coord,int32_t chunk_dim)
-        {
-            return {
-                coord.x * chunk_dim,
-                coord.y * chunk_dim,
-                coord.z * chunk_dim
-            };
-
-        }
+        Bonxai::CoordT chunkCoordToVoxelCoord(const Bonxai::CoordT& coord,int32_t chunk_dim);
 
         /**
          * @brief Maps a 3D point in the map frame to a voxel coordinate that is relative to the voxel origin of the chunk
@@ -171,24 +86,7 @@ namespace RM
          * @param int32_t chunk_dim. The resolution of a chunk in terms of voxels
          * @return Bonxai::CoordT
          */
-        Bonxai::CoordT mapFramePointToChunkFrameCoord(const PCLPoint& mP,double resolution,int32_t chunk_dim)
-        {
-            using Coord = Bonxai::CoordT;
-
-            // Convert the Map Frame Point mP to Map Frame Voxel Coordinate mVC
-            Coord mVC = mapPointToVoxelCoord(mP,resolution);
-
-            // Find the Coordinate of the Chunk mCC
-            Coord mCC = voxelCoordToChunkCoord(mVC,chunk_dim);
-
-            // Get the Origin Voxel in the Chunk as a Voxel Coordinate in map frame
-            Coord mOriginVC = chunkCoordToVoxelCoord(mCC,chunk_dim);
-
-            // And Finally, make the mVC we calculated earlier relative to mOriginVC
-            Coord cVC = mVC - mOriginVC;
-
-            return cVC;
-        }
+        Bonxai::CoordT mapFramePointToChunkFrameCoord(const PCLPoint& mP,double resolution,int32_t chunk_dim);
         
         /**
          * Maps a 3D point from map frame into chunk frame
@@ -197,20 +95,7 @@ namespace RM
          * @param int32_t chunk_dim
          * @return PCLPoint
          */
-        PCLPoint mapFramePointToChunkFramePoint(const PCLPoint& mp,double resolution, int32_t chunk_dim)
-        {
-            auto mVC = mapPointToVoxelCoord(mp,resolution);
-            auto mCC = voxelCoordToChunkCoord(mVC,chunk_dim);
-            auto mCC_Voxel = chunkCoordToVoxelCoord(mCC,chunk_dim);
-            PCLPoint chunk_origin = voxelCoordToMapPoint(mCC_Voxel,resolution);
-
-            PCLPoint new_pt(mp.x - chunk_origin.x,
-                            mp.y - chunk_origin.y,
-                            mp.z - chunk_origin.z);
-            
-            return new_pt;
-        }
-
+        PCLPoint mapFramePointToChunkFramePoint(const PCLPoint& mp,double resolution, int32_t chunk_dim);
     }
 }
 

--- a/include/rolling_map/utils.h
+++ b/include/rolling_map/utils.h
@@ -1,0 +1,217 @@
+#ifndef ROLLING_MAP__UTILS_H
+#define ROLLING_MAP__UTILS_H
+
+#include "bonxai_core/bonxai.hpp"
+
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+
+namespace RM
+{
+    
+    namespace utils
+    {
+        using PCLPoint = pcl::PointXYZ;
+        using PCLPointCloud = pcl::PointCloud<pcl::PointXYZ>;
+        using PCLPointCloudSharedPtr = pcl::PointCloud<pcl::PointXYZ>::Ptr;
+
+
+        /**
+         * @brief Get the 6 face neibors of a chunk
+         * @param Bonxai::CoordT& c
+         * @return std::array<Bonxai::CoordT,6>
+         */
+        std::array<Bonxai::CoordT,6> getFaceNeibors(const Bonxai::CoordT& coord)
+        {
+            //Follow the right-handle rule system X(front),Y(Left), Z(Up)
+            return {{
+                {coord.x + 1, coord.y, coord.z}, //front
+                {coord.x - 1, coord.y, coord.z}, //back
+                {coord.x, coord.y + 1, coord.z}, //left
+                {coord.x, coord.y - 1, coord.z}, //right
+                {coord.x, coord.y, coord.z + 1}, //top
+                {coord.x, coord.y, coord.z - 1}  //down
+            }};
+        }
+
+        /**
+         * @brief Get the 12 edge neibors of a chunk
+         * @param Bonxai::CoordT& c
+         * @return std::array<Bonxai::CoordT,12>
+         */
+        std::array<Bonxai::CoordT,12> getEdgeNeibors(const Bonxai::CoordT& coord)
+        {
+            //Follow the right-handle rule system X(front),Y(Left), Z(Up)
+            return {{
+                // xy-plane edges
+                {coord.x - 1, coord.y - 1, coord.z}, //back-right
+                {coord.x - 1, coord.y + 1, coord.z}, //back-left
+                {coord.x + 1, coord.y - 1, coord.z}, //front-right
+                {coord.x + 1, coord.y + 1, coord.z}, //front-left
+
+                // xz-plane edges
+                {coord.x - 1, coord.y, coord.z - 1}, //back-down
+                {coord.x - 1, coord.y, coord.z + 1}, //back-top
+                {coord.x + 1, coord.y, coord.z - 1}, //front-down
+                {coord.x + 1, coord.y, coord.z + 1}, //front-top
+
+                // yz-plane edges
+                {coord.x, coord.y - 1, coord.z - 1}, //right-down
+                {coord.x, coord.y - 1, coord.z + 1}, //right-top
+                {coord.x, coord.y + 1, coord.z - 1}, //left-down
+                {coord.x, coord.y + 1, coord.z + 1}  //left-top
+            }};
+        }
+
+        /**
+         * @brief Get the 8 corner neibors of a chunk
+         * @param Bonxai::CoordT& c
+         * @return std::array<Bonxai::CoordT,8>
+         */
+        std::array<Bonxai::CoordT,8> getCornerNeibors(const Bonxai::CoordT& coord)
+        {
+            //Follow the right-handle rule system X(front),Y(Left), Z(Up)
+            return {{
+                {coord.x - 1, coord.y - 1, coord.z - 1}, //back  - right  -  down
+                {coord.x - 1, coord.y - 1, coord.z + 1}, //back  - right  -  top
+                {coord.x - 1, coord.y + 1, coord.z - 1}, //back  - left   -  down
+                {coord.x - 1, coord.y + 1, coord.z + 1}, //back  - left  -   top
+                {coord.x + 1, coord.y - 1, coord.z - 1}, //front - right  -  down
+                {coord.x + 1, coord.y - 1, coord.z + 1}, //front - right  -  top
+                {coord.x + 1, coord.y + 1, coord.z - 1}, //front - left   -  down
+                {coord.x + 1, coord.y + 1, coord.z + 1}  //front - left   -  top
+            }};
+        }
+
+        /**
+         * @brief Converts a 3D point in map frame to a voxel coord. Exactly the same as Bonxai::posToCoord
+         * @param PCLPoint& point
+         * param double resolution
+         * @return Bonxai::CoordT
+         */
+        Bonxai::CoordT mapPointToVoxelCoord(const PCLPoint& point,double resolution)
+        {
+            double inv_resolution = 1.0 / resolution;
+            return {
+                static_cast<int32_t>(std::floor(point.x * inv_resolution)),
+                static_cast<int32_t>(std::floor(point.y * inv_resolution)),
+                static_cast<int32_t>(std::floor(point.z * inv_resolution))};
+        }
+
+        /**
+         * @brief Converts a voxel coord to a 3D point in map frame. Exactly the same as Bonxai::coordToPos
+         * @param Bonxai::CoordT& coord
+         * param double resolution
+         * @return PCLPoint
+         */
+        PCLPoint voxelCoordToMapPoint(const Bonxai::CoordT& coord,double resolution)
+        {
+            return 
+            {
+            (static_cast<double>(coord.x)) * resolution,
+            (static_cast<double>(coord.y)) * resolution,
+            (static_cast<double>(coord.z)) * resolution};
+
+        }
+
+        /**
+         * @brief Convert a voxel coord to a 3D point in the map frame to the center of the voxel
+         * @param Bonxai::CoordT& coord
+         * @param double resolution
+         * @return PCLPoint
+         */
+        PCLPoint voxelCoordToMapCenterPoint(const Bonxai::CoordT& coord, double resolution)
+        {
+            double half = 0.5 * resolution;
+            return {
+            (static_cast<double>(coord.x)) * resolution + half,
+            (static_cast<double>(coord.y)) * resolution + half,
+            (static_cast<double>(coord.z)) * resolution + half};
+        }
+
+        /**
+         * @brief COnverts a voxel coord to a chunk coordinate
+         * @param Bonxai::CoordT& coord
+         * @param int32_t chunk_dim. The resolution of a chunk in terms of voxels
+         * @return CoordT
+         */
+        Bonxai::CoordT voxelCoordToChunkCoord(const Bonxai::CoordT& coord,int32_t chunk_dim)
+        {
+
+            return {
+            coord.x >= 0 ? coord.x / chunk_dim : (coord.x - chunk_dim + 1) / chunk_dim,
+            coord.y >= 0 ? coord.y / chunk_dim : (coord.y - chunk_dim + 1) / chunk_dim,
+            coord.z >= 0 ? coord.z / chunk_dim : (coord.z - chunk_dim + 1) / chunk_dim
+            };
+
+        }
+
+        /**
+         * @brief Maps a chunk coordinate to the voxel coordinate, which is the back right down voxel in the map frame
+         * @param const Bonxai::CoordT& coord
+         * @param int32_t chunk_dim. The resolution of a chunk in terms of voxels
+         * @return Bonxai::CoordT
+         */
+        Bonxai::CoordT chunkCoordToVoxelCoord(const Bonxai::CoordT& coord,int32_t chunk_dim)
+        {
+            return {
+                coord.x * chunk_dim,
+                coord.y * chunk_dim,
+                coord.z * chunk_dim
+            };
+
+        }
+
+        /**
+         * @brief Maps a 3D point in the map frame to a voxel coordinate that is relative to the voxel origin of the chunk
+         * @param const PCLPoint& point
+         * @param double resolution
+         * @param int32_t chunk_dim. The resolution of a chunk in terms of voxels
+         * @return Bonxai::CoordT
+         */
+        Bonxai::CoordT mapFramePointToChunkFrameCoord(const PCLPoint& mP,double resolution,int32_t chunk_dim)
+        {
+            using Coord = Bonxai::CoordT;
+
+            // Convert the Map Frame Point mP to Map Frame Voxel Coordinate mVC
+            Coord mVC = mapPointToVoxelCoord(mP,resolution);
+
+            // Find the Coordinate of the Chunk mCC
+            Coord mCC = voxelCoordToChunkCoord(mVC,chunk_dim);
+
+            // Get the Origin Voxel in the Chunk as a Voxel Coordinate in map frame
+            Coord mOriginVC = chunkCoordToVoxelCoord(mCC,chunk_dim);
+
+            // And Finally, make the mVC we calculated earlier relative to mOriginVC
+            Coord cVC = mVC - mOriginVC;
+
+            return cVC;
+        }
+        
+        /**
+         * Maps a 3D point from map frame into chunk frame
+         * @param const PCLPoint& mp
+         * @param double resolution
+         * @param int32_t chunk_dim
+         * @return PCLPoint
+         */
+        PCLPoint mapFramePointToChunkFramePoint(const PCLPoint& mp,double resolution, int32_t chunk_dim)
+        {
+            auto mVC = mapPointToVoxelCoord(mp,resolution);
+            auto mCC = voxelCoordToChunkCoord(mVC,chunk_dim);
+            auto mCC_Voxel = chunkCoordToVoxelCoord(mCC,chunk_dim);
+            PCLPoint chunk_origin = voxelCoordToMapPoint(mCC_Voxel,resolution);
+
+            PCLPoint new_pt(mp.x - chunk_origin.x,
+                            mp.y - chunk_origin.y,
+                            mp.z - chunk_origin.z);
+            
+            return new_pt;
+        }
+
+    }
+}
+
+#endif 

--- a/src/chunk_manager.cpp
+++ b/src/chunk_manager.cpp
@@ -433,12 +433,12 @@ namespace RM
 
         //Replace the new chunks array with the existing chunks.
         chunks_ = std::move(new_chunks);
-        //Replace the new states array with the existing states
+        //Replace the new metadata array with the existing states
         chunks_metadata_ = std::move(new_chunks_md);
         //Create a vector for the read tasks
         std::vector<std::pair<ChunkKey,size_t>> read_tasks;
         //Loop through the updated states and chunks
-        for (size_t i = 0 ; i < 27 ; ++i)
+        for (size_t i = 0 ; i < CACHE_SIZE ; ++i)
         {
             const Chunkmd updated_md = chunks_metadata_.at(i);
             //Read it if its not a neibor of the current source chunk and its not the current source chunk

--- a/src/chunk_manager.cpp
+++ b/src/chunk_manager.cpp
@@ -60,7 +60,7 @@ namespace RM
     void ChunkManager::initFirstChunks(Bonxai::CoordT &source_chunk)
     {
         setSourceCoord(source_chunk);
-        for (size_t i = 0; i < 27; ++i)
+        for (size_t i = 0 ; i < CACHE_SIZE; ++i)
         {
             //Make a new map
             MapPtr mptr = std::make_shared<Bonxai::OccupancyMap>(map_params_.resolution,moption_);
@@ -293,7 +293,7 @@ namespace RM
         }
         points.clear();
 
-        for (int i = 0 ; i < chunks_.size() ; ++i)
+        for (size_t i = 0 ; i < CACHE_SIZE ; ++i)
         {
             Bonxai::CoordT cc_origin_voxel_map = utils::chunkCoordToVoxelCoord(chunks_metadata_[i].coord,chunk_params_.chunk_dim);
 
@@ -321,7 +321,7 @@ namespace RM
 
         points.clear();
 
-        for (int i = 0 ; i < chunks_.size() ; ++i)
+        for (size_t i = 0 ; i < CACHE_SIZE ; ++i)
         {
             Bonxai::CoordT cc_origin_voxel_map = utils::chunkCoordToVoxelCoord(chunks_metadata_[i].coord,chunk_params_.chunk_dim);
 
@@ -672,7 +672,6 @@ namespace RM
     {
         {
             std::lock_guard<std::mutex> lock(read_mutex_);
-            RCLCPP_INFO_STREAM(rclcpp::get_logger("rolling-map-node"),"Push Request to read key: " << key << " CacheIdx: "<< cache_index);
             read_queue_.emplace(key,cache_index);
             rq_size_ ++;
         }

--- a/src/map_manager.cpp
+++ b/src/map_manager.cpp
@@ -23,10 +23,10 @@ namespace RM
     bool MapManager::updateMap(PCLPointCloud& points,PCLPoint& origin)
     {
         //The voxel coordinate where the origin is found in
-        auto voxel_coord_sensor = this->mapPointToVoxelCoord(origin);
+        auto voxel_coord_sensor = utils::mapPointToVoxelCoord(origin,mp_.resolution);
 
         //The chunk coordinate where the origin voxel is found in
-        auto chunk_coord_sensor = this->voxelCoordToChunkCoord(voxel_coord_sensor);
+        auto chunk_coord_sensor = utils::voxelCoordToChunkCoord(voxel_coord_sensor,cp_.chunk_dim);
 
         if (first_update_)
         {
@@ -41,7 +41,6 @@ namespace RM
             return able_to_update;
         }
     }
-
     
     void MapManager::getFreeVoxels(PCLPointCloud& points)
     {
@@ -52,124 +51,5 @@ namespace RM
     {
         chunk_manager_->getAllOccupiedVoxels(points);
     }
-
-    std::array<Bonxai::CoordT,6> MapManager::getFaceNeibors(const Bonxai::CoordT& coord)
-    {
-        //Follow the right-handle rule system X(front),Y(Left), Z(Up)
-        return {{
-            {coord.x + 1, coord.y, coord.z}, //front
-            {coord.x - 1, coord.y, coord.z}, //back
-            {coord.x, coord.y + 1, coord.z}, //left
-            {coord.x, coord.y - 1, coord.z}, //right
-            {coord.x, coord.y, coord.z + 1}, //top
-            {coord.x, coord.y, coord.z - 1}  //down
-        }};
-    }
-
-    std::array<Bonxai::CoordT,12> MapManager::getEdgeNeibors(const Bonxai::CoordT& coord)
-    {
-        //Follow the right-handle rule system X(front),Y(Left), Z(Up)
-        return {{
-            // xy-plane edges
-            {coord.x - 1, coord.y - 1, coord.z}, //back-right
-            {coord.x - 1, coord.y + 1, coord.z}, //back-left
-            {coord.x + 1, coord.y - 1, coord.z}, //front-right
-            {coord.x + 1, coord.y + 1, coord.z}, //front-left
-
-            // xz-plane edges
-            {coord.x - 1, coord.y, coord.z - 1}, //back-down
-            {coord.x - 1, coord.y, coord.z + 1}, //back-top
-            {coord.x + 1, coord.y, coord.z - 1}, //front-down
-            {coord.x + 1, coord.y, coord.z + 1}, //front-top
-
-            // yz-plane edges
-            {coord.x, coord.y - 1, coord.z - 1}, //right-down
-            {coord.x, coord.y - 1, coord.z + 1}, //right-top
-            {coord.x, coord.y + 1, coord.z - 1}, //left-down
-            {coord.x, coord.y + 1, coord.z + 1}  //left-top
-        }};
-    }
-
-    std::array<Bonxai::CoordT,8> MapManager::getCornerNeibors(const Bonxai::CoordT& coord) 
-    {
-        //Follow the right-handle rule system X(front),Y(Left), Z(Up)
-        return {{
-            {coord.x - 1, coord.y - 1, coord.z - 1}, //back  - right  -  down
-            {coord.x - 1, coord.y - 1, coord.z + 1}, //back  - right  -  top
-            {coord.x - 1, coord.y + 1, coord.z - 1}, //back  - left   -  down
-            {coord.x - 1, coord.y + 1, coord.z + 1}, //back  - left  -   top
-            {coord.x + 1, coord.y - 1, coord.z - 1}, //front - right  -  down
-            {coord.x + 1, coord.y - 1, coord.z + 1}, //front - right  -  top
-            {coord.x + 1, coord.y + 1, coord.z - 1}, //front - left   -  down
-            {coord.x + 1, coord.y + 1, coord.z + 1}  //front - left   -  top
-        }};
-    }
-
-    Bonxai::CoordT MapManager::mapPointToVoxelCoord(const PCLPoint& point)
-    {
-        return {
-            static_cast<int32_t>(std::floor(point.x * inv_resolution_)),
-            static_cast<int32_t>(std::floor(point.y * inv_resolution_)),
-            static_cast<int32_t>(std::floor(point.z * inv_resolution_))};
-    }
-
-    MapManager::PCLPoint MapManager::voxelCoordToMapPoint(const Bonxai::CoordT& coord)
-    {
-        return {
-            (static_cast<double>(coord.x)) * mp_.resolution,
-            (static_cast<double>(coord.y)) * mp_.resolution,
-            (static_cast<double>(coord.z)) * mp_.resolution};
-    }
-
-    MapManager::PCLPoint MapManager::voxelCoordToMapCenterPoint(const Bonxai::CoordT& coord)
-    {
-        double half = 0.5 * mp_.resolution;
-        return {
-            (static_cast<double>(coord.x)) * mp_.resolution + half,
-            (static_cast<double>(coord.y)) * mp_.resolution + half,
-            (static_cast<double>(coord.z)) * mp_.resolution + half};
-    }
-
-    Bonxai::CoordT MapManager::voxelCoordToChunkCoord(const Bonxai::CoordT& vc)
-    {
-        const int32_t chunk_size = cp_.chunk_dim;
-
-        return {
-        vc.x >= 0 ? vc.x / chunk_size : (vc.x - chunk_size + 1) / chunk_size,
-        vc.y >= 0 ? vc.y / chunk_size : (vc.y - chunk_size + 1) / chunk_size,
-        vc.z >= 0 ? vc.z / chunk_size : (vc.z - chunk_size + 1) / chunk_size
-        };
-    }
-
-    Bonxai::CoordT MapManager::chunkCoordToVoxelCoord(const Bonxai::CoordT& cc)
-    {
-        const int32_t chunk_size = cp_.chunk_dim;
-        return {
-            cc.x * chunk_size,
-            cc.y * chunk_size,
-            cc.z * chunk_size
-        };
-    }
-
-    Bonxai::CoordT MapManager::mapFramePointToChunkFrameCoord(const PCLPoint& mP)
-    {
-        using Coord = Bonxai::CoordT;
-
-        // Convert the Map Frame Point mP to Map Frame Voxel Coordinate mVC
-        Coord mVC = this->mapPointToVoxelCoord(mP);
-
-        // Find the Coordinate of the Chunk mCC
-        Coord mCC = this->voxelCoordToChunkCoord(mVC);
-
-        // Get the Origin Voxel in the Chunk as a Voxel Coordinate in map frame
-        Coord mOriginVC = this->chunkCoordToVoxelCoord(mCC);
-
-        // And Finally, make the mVC we calculated earlier relative to mOriginVC
-        Coord cVC = mVC - mOriginVC;
-
-        return cVC;
-
-    }
-
 
 }// namespace RM

--- a/src/rolling_map.cpp
+++ b/src/rolling_map.cpp
@@ -1,4 +1,4 @@
-#include "rolling_map/rolling_map.h"
+#include "rolling_map/map_server.h"
 
 namespace RM
 {
@@ -251,12 +251,6 @@ void RollingMapNode::cloudCallback(const sensor_msgs::msg::PointCloud2::ConstSha
     // RCLCPP_INFO_STREAM(this->get_logger(), "Callback Completion Time: " << elapsed_s           << "s\n"
     //                                     << "Total Callback Hits: "      << num_callback_hits_  << "\n"
     //                                     << "Average Completion Time: "  << elapsed_avg_time_s_ << "s\n");
-}
-
-
-void RollingMapNode::publishMap()
-{
-    return;
 }
 
 } // namespace RM

--- a/src/rolling_map.cpp
+++ b/src/rolling_map.cpp
@@ -230,8 +230,6 @@ void RollingMapNode::cloudCallback(const sensor_msgs::msg::PointCloud2::ConstSha
 
     if (viz_free_)
     {
-        RCLCPP_INFO_STREAM(rclcpp::get_logger("rolling-map-node"),"FreeVoxels: " << occupied_voxels_.size());
-
         if (did_update_happen)
         {
             map_manager_.getOccupiedVoxels(free_voxels_);

--- a/src/rolling_map_node.cpp
+++ b/src/rolling_map_node.cpp
@@ -1,5 +1,5 @@
 #include "rclcpp/rclcpp.hpp"
-#include "rolling_map/rolling_map.h"
+#include "rolling_map/map_server.h"
 
 int main(int argc, char * argv[])
 {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,143 @@
+#include "rolling_map/utils.h"
+
+namespace RM
+{
+    
+    namespace utils
+    {
+        std::array<Bonxai::CoordT,6> getFaceNeibors(const Bonxai::CoordT& coord)
+        {
+            //Follow the right-handle rule system X(front),Y(Left), Z(Up)
+            return {{
+                {coord.x + 1, coord.y, coord.z}, //front
+                {coord.x - 1, coord.y, coord.z}, //back
+                {coord.x, coord.y + 1, coord.z}, //left
+                {coord.x, coord.y - 1, coord.z}, //right
+                {coord.x, coord.y, coord.z + 1}, //top
+                {coord.x, coord.y, coord.z - 1}  //down
+            }};
+        }
+
+        std::array<Bonxai::CoordT,12> getEdgeNeibors(const Bonxai::CoordT& coord)
+        {
+            //Follow the right-handle rule system X(front),Y(Left), Z(Up)
+            return {{
+                // xy-plane edges
+                {coord.x - 1, coord.y - 1, coord.z}, //back-right
+                {coord.x - 1, coord.y + 1, coord.z}, //back-left
+                {coord.x + 1, coord.y - 1, coord.z}, //front-right
+                {coord.x + 1, coord.y + 1, coord.z}, //front-left
+
+                // xz-plane edges
+                {coord.x - 1, coord.y, coord.z - 1}, //back-down
+                {coord.x - 1, coord.y, coord.z + 1}, //back-top
+                {coord.x + 1, coord.y, coord.z - 1}, //front-down
+                {coord.x + 1, coord.y, coord.z + 1}, //front-top
+
+                // yz-plane edges
+                {coord.x, coord.y - 1, coord.z - 1}, //right-down
+                {coord.x, coord.y - 1, coord.z + 1}, //right-top
+                {coord.x, coord.y + 1, coord.z - 1}, //left-down
+                {coord.x, coord.y + 1, coord.z + 1}  //left-top
+            }};
+        }
+
+        std::array<Bonxai::CoordT,8> getCornerNeibors(const Bonxai::CoordT& coord)
+        {
+            //Follow the right-handle rule system X(front),Y(Left), Z(Up)
+            return {{
+                {coord.x - 1, coord.y - 1, coord.z - 1}, //back  - right  -  down
+                {coord.x - 1, coord.y - 1, coord.z + 1}, //back  - right  -  top
+                {coord.x - 1, coord.y + 1, coord.z - 1}, //back  - left   -  down
+                {coord.x - 1, coord.y + 1, coord.z + 1}, //back  - left  -   top
+                {coord.x + 1, coord.y - 1, coord.z - 1}, //front - right  -  down
+                {coord.x + 1, coord.y - 1, coord.z + 1}, //front - right  -  top
+                {coord.x + 1, coord.y + 1, coord.z - 1}, //front - left   -  down
+                {coord.x + 1, coord.y + 1, coord.z + 1}  //front - left   -  top
+            }};
+        }
+
+        Bonxai::CoordT mapPointToVoxelCoord(const PCLPoint& point,double resolution)
+        {
+            double inv_resolution = 1.0 / resolution;
+            return {
+                static_cast<int32_t>(std::floor(point.x * inv_resolution)),
+                static_cast<int32_t>(std::floor(point.y * inv_resolution)),
+                static_cast<int32_t>(std::floor(point.z * inv_resolution))};
+        }
+
+        PCLPoint voxelCoordToMapPoint(const Bonxai::CoordT& coord,double resolution)
+        {
+            return 
+            {
+            (static_cast<double>(coord.x)) * resolution,
+            (static_cast<double>(coord.y)) * resolution,
+            (static_cast<double>(coord.z)) * resolution};
+
+        }
+
+        PCLPoint voxelCoordToMapCenterPoint(const Bonxai::CoordT& coord, double resolution)
+        {
+            double half = 0.5 * resolution;
+            return {
+            (static_cast<double>(coord.x)) * resolution + half,
+            (static_cast<double>(coord.y)) * resolution + half,
+            (static_cast<double>(coord.z)) * resolution + half};
+        }
+
+        Bonxai::CoordT voxelCoordToChunkCoord(const Bonxai::CoordT& coord,int32_t chunk_dim)
+        {
+
+            return {
+            coord.x >= 0 ? coord.x / chunk_dim : (coord.x - chunk_dim + 1) / chunk_dim,
+            coord.y >= 0 ? coord.y / chunk_dim : (coord.y - chunk_dim + 1) / chunk_dim,
+            coord.z >= 0 ? coord.z / chunk_dim : (coord.z - chunk_dim + 1) / chunk_dim
+            };
+
+        }
+
+        Bonxai::CoordT chunkCoordToVoxelCoord(const Bonxai::CoordT& coord,int32_t chunk_dim)
+        {
+            return {
+                coord.x * chunk_dim,
+                coord.y * chunk_dim,
+                coord.z * chunk_dim
+            };
+
+        }
+
+        Bonxai::CoordT mapFramePointToChunkFrameCoord(const PCLPoint& mP,double resolution,int32_t chunk_dim)
+        {
+            using Coord = Bonxai::CoordT;
+
+            // Convert the Map Frame Point mP to Map Frame Voxel Coordinate mVC
+            Coord mVC = mapPointToVoxelCoord(mP,resolution);
+
+            // Find the Coordinate of the Chunk mCC
+            Coord mCC = voxelCoordToChunkCoord(mVC,chunk_dim);
+
+            // Get the Origin Voxel in the Chunk as a Voxel Coordinate in map frame
+            Coord mOriginVC = chunkCoordToVoxelCoord(mCC,chunk_dim);
+
+            // And Finally, make the mVC we calculated earlier relative to mOriginVC
+            Coord cVC = mVC - mOriginVC;
+
+            return cVC;
+        }
+        
+        PCLPoint mapFramePointToChunkFramePoint(const PCLPoint& mp,double resolution, int32_t chunk_dim)
+        {
+            auto mVC = mapPointToVoxelCoord(mp,resolution);
+            auto mCC = voxelCoordToChunkCoord(mVC,chunk_dim);
+            auto mCC_Voxel = chunkCoordToVoxelCoord(mCC,chunk_dim);
+            PCLPoint chunk_origin = voxelCoordToMapPoint(mCC_Voxel,resolution);
+
+            PCLPoint new_pt(mp.x - chunk_origin.x,
+                            mp.y - chunk_origin.y,
+                            mp.z - chunk_origin.z);
+            
+            return new_pt;
+        }
+
+    }
+}


### PR DESCRIPTION
* Added a ChunkMetadata struct and a 27 array of metadatas to handle state updates more cleanly.
* Removed the touched_once array, it is now part of the chunk metadata
* Removed noisy debug statements
* Moved helpers to a RM::utils namespace to ensure DRY
* Updated header guard names