### PR TITLE
Add persistent static and dynamic mapping

### DIFF
--- a/bonxai_core/include/bonxai_core/grid_coord.hpp
+++ b/bonxai_core/include/bonxai_core/grid_coord.hpp
@@ -69,6 +69,7 @@ struct CoordT {
 
   [[nodiscard]] bool operator==(const CoordT& other) const;
   [[nodiscard]] bool operator!=(const CoordT& other) const;
+  [[nodiscard]] bool operator<(const CoordT& other) const;
 
   [[nodiscard]] CoordT operator+(const CoordT& other) const;
   [[nodiscard]] CoordT operator-(const CoordT& other) const;
@@ -180,6 +181,16 @@ inline bool CoordT::operator==(const CoordT& other) const {
 
 inline bool CoordT::operator!=(const CoordT& other) const {
   return !(*this == other);
+}
+
+inline bool CoordT::operator<(const CoordT& other) const {
+  if (x != other.x) {
+    return x < other.x;
+  }
+  if (y != other.y) {
+    return y < other.y;
+  }
+  return z < other.z;
 }
 
 inline CoordT CoordT::operator+(const CoordT& other) const {

--- a/bonxai_map/include/bonxai_map/occupancy_map.hpp
+++ b/bonxai_map/include/bonxai_map/occupancy_map.hpp
@@ -431,6 +431,19 @@ public:
             points.emplace_back(p.x, p.y, p.z);
         }
     }
+
+    /**
+     * @brief Convert a world-space point into a voxel coordinate using this map's resolution.
+     */
+    [[nodiscard]] CoordT worldToVoxel(const Vector3D& point) const;
+
+    /**
+     * @brief Apply temporal decay to occupied voxels so dynamic obstacles can fade over time.
+     *
+     * @param dt_seconds Elapsed time since the previous decay update.
+     * @param decay_time_seconds Time constant over which occupancy decays toward free-space.
+     */
+    void applyTemporalDecay(double dt_seconds, double decay_time_seconds);
     
     // ========================================================================
     // Updates (non-const methods)
@@ -449,6 +462,14 @@ public:
      * @note Prefer this overload if you already have voxel coordinates
      */
     void addHitPoint(const CoordT& coord);
+
+    /**
+     * @brief Reset a voxel to unknown occupancy.
+     *
+     * Used when a formerly stable obstacle disappears and must be removed
+     * from the persistent layer.
+     */
+    void resetPoint(const CoordT& coord);
     
     /**
      * @brief Add a miss observation (free space)

--- a/bonxai_map/src/occupancy_map.cpp
+++ b/bonxai_map/src/occupancy_map.cpp
@@ -206,6 +206,45 @@ Occupancy::OccupancyMapStats OccupancyMap::getQuickStats() const noexcept {
     return stats;
 }
 
+CoordT OccupancyMap::worldToVoxel(const Vector3D& point) const {
+    return grid_.posToCoord(point);
+}
+
+void OccupancyMap::applyTemporalDecay(double dt_seconds, double decay_time_seconds) {
+    if (dt_seconds <= 0.0 || decay_time_seconds <= 0.0) {
+        return;
+    }
+
+    ensureAccessorValid();
+
+    const double decay_factor = std::exp(-dt_seconds / decay_time_seconds);
+    auto visitor = [this, decay_factor](Occupancy::CellOcc& cell, const CoordT&) {
+        if (cell.probability_log == Occupancy::UnknownProbability) {
+            return;
+        }
+
+        const float current_probability = Occupancy::prob(cell.probability_log);
+        // Decay evidence toward "unknown" (p = 0.5), not toward free
+        // space.  Multiplying the probability itself by decay_factor made a
+        // fresh hit fall below the occupied threshold after only a few timer
+        // ticks, which made the dynamic layer appear empty.
+        const float target_probability = std::max(
+            1.0e-6f,
+            std::min(
+                1.0f - 1.0e-6f,
+                0.5f + (current_probability - 0.5f) * static_cast<float>(decay_factor))
+        );
+
+        cell.probability_log = std::clamp(
+            Occupancy::logods(target_probability),
+            options_.clamp_min_log,
+            options_.clamp_max_log
+        );
+    };
+
+    grid_.forEachCell(visitor);
+}
+
 Occupancy::OccupancyMapStats OccupancyMap::getStats(bool compute_expensive) const {
     Occupancy::OccupancyMapStats stats = getQuickStats();
     
@@ -346,6 +385,16 @@ void OccupancyMap::addHitPoint(const CoordT& coord) {
         cell->update_id = update_count_;
         hit_coords_.push_back(coord);
     }
+}
+
+void OccupancyMap::resetPoint(const CoordT& coord) {
+    ensureAccessorValid();
+    Occupancy::CellOcc* cell = accessor_->value(coord, true);
+    // isUnknown() is defined relative to the configured occupancy threshold,
+    // which is not guaranteed to be bit-identical to UnknownProbability.
+    cell->probability_log = options_.occupancy_threshold_log;
+    // Make the cell eligible for an update in the current insertion cycle.
+    cell->update_id = 4;
 }
 
 void OccupancyMap::addMissPoint(const Vector3D& point) {

--- a/bonxai_map/test/test_occupancy_map.cpp
+++ b/bonxai_map/test/test_occupancy_map.cpp
@@ -519,6 +519,45 @@ TEST(OccupancyMapTest, GetOccupiedVoxelsAsPoints) {
   EXPECT_FALSE(occupied_points.empty());
 }
 
+TEST(OccupancyMapTest, TemporalDecayReducesOccupancy) {
+  Bonxai::OccupancyMap map(0.1);
+  const Eigen::Vector3d point(0.05, 0.05, 0.05);
+
+  map.addHitPoint(point);
+  const auto coord = map.worldToVoxel(point);
+
+  EXPECT_TRUE(map.isOccupied(coord));
+
+  map.applyTemporalDecay(10.0, 0.1);
+
+  EXPECT_FALSE(map.isOccupied(coord));
+  EXPECT_TRUE(map.isUnknown(coord));
+}
+
+TEST(OccupancyMapTest, TemporalDecayDoesNotTurnOccupancyIntoFreeSpace) {
+  Bonxai::OccupancyMap map(0.1);
+  const auto coord = map.worldToVoxel(Eigen::Vector3d(0.05, 0.05, 0.05));
+
+  map.addHitPoint(coord);
+  map.applyTemporalDecay(1.0, 2.0);
+
+  EXPECT_TRUE(map.isOccupied(coord));
+  EXPECT_FALSE(map.isFree(coord));
+}
+
+TEST(OccupancyMapTest, ResetPointRemovesPersistentOccupancy) {
+  Bonxai::OccupancyMap map(0.1);
+  const auto coord = map.worldToVoxel(Eigen::Vector3d(0.05, 0.05, 0.05));
+
+  map.addHitPoint(coord);
+  ASSERT_TRUE(map.isOccupied(coord));
+
+  map.resetPoint(coord);
+
+  EXPECT_FALSE(map.isOccupied(coord));
+  EXPECT_TRUE(map.isUnknown(coord));
+}
+
 TEST(OccupancyMapTest, GetFreeVoxelsAsPoints) {
   Bonxai::OccupancyMap map(0.1);
   

--- a/bonxai_ros/CMakeLists.txt
+++ b/bonxai_ros/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(Eigen3 REQUIRED)
 find_package(bonxai_core REQUIRED)
 find_package(bonxai_map REQUIRED)
 find_package(bonxai_msgs REQUIRED)
+find_package(surf_multirobot_msgs REQUIRED)
 
 # Create BonxaiServer library (for component and linking)
 add_library(bonxai_server_lib SHARED
@@ -67,6 +68,7 @@ ament_target_dependencies(bonxai_server_lib
     tf2_eigen
     pcl_conversions
     bonxai_msgs
+    surf_multirobot_msgs
 )
 
 # Register as composable node (for component containers)
@@ -142,6 +144,7 @@ ament_export_dependencies(
   bonxai_core
   bonxai_map
   bonxai_msgs
+  surf_multirobot_msgs
 )
 
 # Export include directories

--- a/bonxai_ros/CMakeLists.txt
+++ b/bonxai_ros/CMakeLists.txt
@@ -129,6 +129,7 @@ ament_export_dependencies(
   rclcpp
   rclcpp_components
   std_msgs
+  std_srvs
   sensor_msgs
   geometry_msgs
   visualization_msgs

--- a/bonxai_ros/include/bonxai_ros/bonxai_server.hpp
+++ b/bonxai_ros/include/bonxai_ros/bonxai_server.hpp
@@ -3,11 +3,14 @@
 #include <memory>
 #include <string>
 #include <chrono>
+#include <map>
+#include <tuple>
 
 // ROS2
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <std_srvs/srv/trigger.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/buffer.h>
@@ -34,7 +37,8 @@ namespace Bonxai
 
 struct BonxaiParams
 {
-  double resolution{0.0};
+  double static_resolution{0.0};
+  double dynamic_resolution{0.0};
   std::string frame_id;
   std::string base_frame_id;
   std::string topic_in;
@@ -56,15 +60,38 @@ struct BonxaiParams
   bool enable_stats{true};
   bool quick_stats{true};
   bool publish_occupied_voxels{true};
-  double stats_publish_rate{1.0};  // Hz
+  double static_voxel_publish_rate{1.0};  // Hz
+  double dynamic_voxel_publish_rate{5.0};  // Hz
+
+  // Dynamic obstacles
+  bool dynamic_obstacles_enabled{true};
+  double dynamic_obstacle_decay_time_sec{2.0};
+  double dynamic_obstacle_decay_interval_sec{0.25};
+  double dynamic_obstacle_static_demotion_time_sec{20.0};
+  int dynamic_obstacle_static_stability_hits{3};
+  double dynamic_obstacle_static_stability_time_sec{1.0};
+  double dynamic_obstacle_min_probability{0.05};
+
+  // Static map persistence
+  std::string static_map_path;
+  bool static_map_load_on_startup{false};
+  bool static_map_save_on_shutdown{false};
   
+};
+
+struct DynamicCellState
+{
+  uint32_t consecutive_hits{0};
+  std::chrono::steady_clock::time_point last_seen{std::chrono::steady_clock::now()};
+  bool promoted_to_static{false};
+  Bonxai::CoordT promoted_static_coord{};
 };
 
 class BonxaiServer : public rclcpp::Node
 {
 public:
   explicit BonxaiServer(const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
-  ~BonxaiServer() = default;
+  ~BonxaiServer() override;
 
 private:
   // Initialization methods
@@ -86,19 +113,42 @@ private:
   void handle_get_free_voxels(
     const std::shared_ptr<bonxai_msgs::srv::GetFreeVoxels::Request> request,
     std::shared_ptr<bonxai_msgs::srv::GetFreeVoxels::Response> response);
+
+  void handle_save_static_map(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+  void handle_load_static_map(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+  bool save_static_map(std::string& error_message) const;
+  bool load_static_map(std::string& error_message);
   
   // Timer callbacks
   void cleanup_timer_callback();
   void stats_timer_callback();
+  void static_voxel_timer_callback();
+  void dynamic_voxel_timer_callback();
 
   // Helper: Fill VoxelGrid message from coordinate vector
   void fill_voxel_grid_msg(
     const std::vector<Bonxai::CoordT>& coords,
     bonxai_msgs::msg::VoxelGrid& msg);
 
+  void update_dynamic_obstacle_layer(
+    const std::vector<Eigen::Vector3d>& map_points,
+    const Eigen::Vector3d& sensor_origin);
+
+  void get_dynamic_obstacle_voxels(std::vector<Bonxai::CoordT>& coords) const;
+  Bonxai::CoordT dynamic_to_static_coord(const Bonxai::CoordT& coord) const;
+  bool dynamic_voxel_overlaps_static(const Bonxai::CoordT& coord) const;
+  void reconcile_dynamic_with_static_map();
+
+  void decay_dynamic_obstacles();
+
   void fill_pcl_msg(
     const std::vector<Bonxai::CoordT>& coords,
-    sensor_msgs::msg::PointCloud2& msg);
+    sensor_msgs::msg::PointCloud2& msg,
+    const Bonxai::OccupancyMap& coordinate_map);
     
   // Helper: Fill OccupancyMapStats message
   void fill_stats_msg(bonxai_msgs::msg::OccupancyMapStats& msg);
@@ -109,8 +159,10 @@ private:
   // Flags
   bool updated_map_once_{false};
 
-  // Occupancy map
+  // Occupancy maps
   std::unique_ptr<Bonxai::OccupancyMap> occupancy_map_;
+  std::unique_ptr<Bonxai::OccupancyMap> dynamic_obstacle_map_;
+  std::map<std::tuple<int32_t, int32_t, int32_t>, DynamicCellState> dynamic_obstacle_states_;
 
   // TF
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
@@ -122,14 +174,21 @@ private:
   // Service servers
   rclcpp::Service<bonxai_msgs::srv::GetOccupiedVoxels>::SharedPtr occupied_voxels_service_;
   rclcpp::Service<bonxai_msgs::srv::GetFreeVoxels>::SharedPtr free_voxels_service_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr save_static_map_service_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr load_static_map_service_;
   
   // Publishers
   rclcpp::Publisher<bonxai_msgs::msg::OccupancyMapStats>::SharedPtr stats_publisher_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr occupied_voxel_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr static_voxel_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr dynamic_voxel_publisher_;
   
   // Timers
   rclcpp::TimerBase::SharedPtr cleanup_timer_;
   rclcpp::TimerBase::SharedPtr stats_timer_;
+  rclcpp::TimerBase::SharedPtr static_voxel_timer_;
+  rclcpp::TimerBase::SharedPtr dynamic_voxel_timer_;
+  rclcpp::TimerBase::SharedPtr dynamic_decay_timer_;
   
   // Statistics
   uint64_t point_clouds_processed_{0};

--- a/bonxai_ros/include/bonxai_ros/bonxai_server.hpp
+++ b/bonxai_ros/include/bonxai_ros/bonxai_server.hpp
@@ -3,8 +3,11 @@
 #include <memory>
 #include <string>
 #include <chrono>
+#include <cstdint>
 #include <map>
+#include <set>
 #include <tuple>
+#include <vector>
 
 // ROS2
 #include <rclcpp/rclcpp.hpp>
@@ -31,6 +34,7 @@
 #include "bonxai_msgs/srv/get_occupied_voxels.hpp"
 #include "bonxai_msgs/srv/get_free_voxels.hpp"
 #include "bonxai_msgs/msg/occupancy_map_stats.hpp"
+#include "surf_multirobot_msgs/msg/voxel_delta.hpp"
 
 namespace Bonxai
 {
@@ -42,6 +46,7 @@ struct BonxaiParams
   std::string frame_id;
   std::string base_frame_id;
   std::string topic_in;
+  std::string delta_topic_in;
 
   double occupancy_min_z{0.0};
   double occupancy_max_z{0.0};
@@ -60,6 +65,7 @@ struct BonxaiParams
   bool enable_stats{true};
   bool quick_stats{true};
   bool publish_occupied_voxels{true};
+  double stats_publish_rate{1.0};  // Hz
   double static_voxel_publish_rate{1.0};  // Hz
   double dynamic_voxel_publish_rate{5.0};  // Hz
 
@@ -75,7 +81,7 @@ struct BonxaiParams
   // Static map persistence
   std::string static_map_path;
   bool static_map_load_on_startup{false};
-  bool static_map_save_on_shutdown{false};
+  bool static_map_save_on_shutdown{true};
   
 };
 
@@ -85,6 +91,15 @@ struct DynamicCellState
   std::chrono::steady_clock::time_point last_seen{std::chrono::steady_clock::now()};
   bool promoted_to_static{false};
   Bonxai::CoordT promoted_static_coord{};
+};
+
+struct RemoteSourceLayer
+{
+  uint64_t map_epoch{0U};
+  uint64_t last_version{0U};
+  bool awaiting_full_refresh{true};
+  std::unique_ptr<Bonxai::OccupancyMap> occupancy;
+  std::set<Bonxai::CoordT> dynamic_voxels;
 };
 
 class BonxaiServer : public rclcpp::Node
@@ -104,6 +119,12 @@ private:
 
   // Callbacks
   void pointcloud_callback(const sensor_msgs::msg::PointCloud2::SharedPtr msg);
+  void voxel_delta_callback(
+    const surf_multirobot_msgs::msg::VoxelDelta::SharedPtr msg);
+  void reset_remote_source(RemoteSourceLayer & source, uint64_t map_epoch);
+  void get_fused_occupied_voxels(
+    std::vector<Bonxai::CoordT> & coords, bool include_static, bool include_dynamic) const;
+  void get_fused_free_voxels(std::vector<Bonxai::CoordT> & coords) const;
   
   // Service handlers
   void handle_get_occupied_voxels(
@@ -163,6 +184,7 @@ private:
   std::unique_ptr<Bonxai::OccupancyMap> occupancy_map_;
   std::unique_ptr<Bonxai::OccupancyMap> dynamic_obstacle_map_;
   std::map<std::tuple<int32_t, int32_t, int32_t>, DynamicCellState> dynamic_obstacle_states_;
+  std::map<std::string, RemoteSourceLayer> remote_sources_;
 
   // TF
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
@@ -170,6 +192,7 @@ private:
 
   // Subscribers
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr cloud_sub_;
+  rclcpp::Subscription<surf_multirobot_msgs::msg::VoxelDelta>::SharedPtr delta_sub_;
   
   // Service servers
   rclcpp::Service<bonxai_msgs::srv::GetOccupiedVoxels>::SharedPtr occupied_voxels_service_;

--- a/bonxai_ros/include/bonxai_ros/bonxai_server.hpp
+++ b/bonxai_ros/include/bonxai_ros/bonxai_server.hpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <cstdint>
 #include <map>
+#include <mutex>
 #include <set>
 #include <tuple>
 #include <vector>
@@ -121,6 +122,8 @@ private:
   void pointcloud_callback(const sensor_msgs::msg::PointCloud2::SharedPtr msg);
   void voxel_delta_callback(
     const surf_multirobot_msgs::msg::VoxelDelta::SharedPtr msg);
+  void apply_voxel_delta(
+    RemoteSourceLayer & source, const surf_multirobot_msgs::msg::VoxelDelta & msg);
   void reset_remote_source(RemoteSourceLayer & source, uint64_t map_epoch);
   void get_fused_occupied_voxels(
     std::vector<Bonxai::CoordT> & coords, bool include_static, bool include_dynamic) const;
@@ -185,6 +188,7 @@ private:
   std::unique_ptr<Bonxai::OccupancyMap> dynamic_obstacle_map_;
   std::map<std::tuple<int32_t, int32_t, int32_t>, DynamicCellState> dynamic_obstacle_states_;
   std::map<std::string, RemoteSourceLayer> remote_sources_;
+  mutable std::mutex remote_sources_mutex_;
 
   // TF
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;

--- a/bonxai_ros/package.xml
+++ b/bonxai_ros/package.xml
@@ -27,6 +27,7 @@
   <depend>bonxai_core</depend>
   <depend>bonxai_map</depend>
   <depend>bonxai_msgs</depend>
+  <depend>surf_multirobot_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/bonxai_ros/params/bonxai_params.yaml
+++ b/bonxai_ros/params/bonxai_params.yaml
@@ -5,7 +5,8 @@ bonxai_server_node:
     topic_in: "/zed/zed_node/point_cloud/cloud_registered"
 
     occupancy:
-      resolution: 0.02
+      static_resolution: 0.02
+      dynamic_resolution: 0.02
       occupancy_min_z: -100.0
       occupancy_max_z: 100.0
       occupancy_threshold: 0.50
@@ -20,8 +21,23 @@ bonxai_server_node:
     server:
       cleanup_interval_sec: 300.0
 
+    map_storage:
+      path: ""
+      load_on_startup: false
+      save_on_shutdown: false
+
     stats:
       enable_stats: true
       quick_stats: true
       publish_occupied_voxels: true
-      publish_rate: 3.0 #Hz
+      static_publish_rate: 1.0
+      dynamic_publish_rate: 5.0
+
+    dynamic_obstacles:
+      enabled: true
+      decay_time_sec: 2.0
+      decay_interval_sec: 0.25
+      static_demotion_time_sec: 20.0
+      static_stability_hits: 30
+      static_stability_time_sec: 3.0
+      min_probability: 0.05

--- a/bonxai_ros/params/bonxai_params.yaml
+++ b/bonxai_ros/params/bonxai_params.yaml
@@ -23,8 +23,8 @@ bonxai_server_node:
 
     map_storage:
       path: ""
-      load_on_startup: false
-      save_on_shutdown: false
+      load_on_startup: true
+      save_on_shutdown: true
 
     stats:
       enable_stats: true

--- a/bonxai_ros/src/bonxai_server.cpp
+++ b/bonxai_ros/src/bonxai_server.cpp
@@ -311,35 +311,83 @@ void BonxaiServer::voxel_delta_callback(
     return;
   }
 
-  auto & source = remote_sources_[msg->source_id];
-  const bool epoch_changed = source.occupancy && source.map_epoch != msg->map_epoch;
-  if (!source.occupancy || epoch_changed) {
-    if (epoch_changed) {
-      RCLCPP_WARN(get_logger(), "Map epoch changed for %s; discarding its old remote layer",
-        msg->source_id.c_str());
+  if (msg->full_refresh) {
+    // The receiver emits an empty version-zero full-refresh message as an epoch
+    // reset sentinel. Preserve any currently displayed layer until the actual
+    // refresh arrives instead of briefly swapping in an empty map.
+    if (count == 0U && msg->version == 0U) {
+      std::lock_guard<std::mutex> lock(remote_sources_mutex_);
+      auto [it, inserted] = remote_sources_.try_emplace(msg->source_id);
+      if (inserted || !it->second.occupancy) {
+        reset_remote_source(it->second, msg->map_epoch);
+      }
+      return;
     }
-    reset_remote_source(source, msg->map_epoch);
+
+    {
+      std::lock_guard<std::mutex> lock(remote_sources_mutex_);
+      const auto it = remote_sources_.find(msg->source_id);
+      if (it != remote_sources_.end() && it->second.occupancy &&
+        it->second.map_epoch != msg->map_epoch)
+      {
+        RCLCPP_WARN(get_logger(),
+          "Map epoch changed for %s; replacing its remote layer after refresh is ready",
+          msg->source_id.c_str());
+      }
+      if (it != remote_sources_.end() && it->second.occupancy &&
+        it->second.map_epoch == msg->map_epoch &&
+        !it->second.awaiting_full_refresh &&
+        msg->version < it->second.last_version)
+      {
+        return;
+      }
+    }
+
+    // Build the replacement without exposing a cleared or partially populated
+    // layer to fused-map publishers. Only the final move assignment is locked.
+    RemoteSourceLayer replacement;
+    reset_remote_source(replacement, msg->map_epoch);
+    apply_voxel_delta(replacement, *msg);
+    {
+      std::lock_guard<std::mutex> lock(remote_sources_mutex_);
+      const auto current = remote_sources_.find(msg->source_id);
+      if (current != remote_sources_.end() && current->second.occupancy &&
+        current->second.map_epoch == msg->map_epoch &&
+        current->second.last_version > msg->version)
+      {
+        return;
+      }
+      remote_sources_[msg->source_id] = std::move(replacement);
+    }
+    updated_map_once_ = updated_map_once_ || count > 0U;
+    return;
   }
 
-  if (source.awaiting_full_refresh && !msg->full_refresh) {
+  std::lock_guard<std::mutex> lock(remote_sources_mutex_);
+  auto & source = remote_sources_[msg->source_id];
+  if (!source.occupancy) {
+    reset_remote_source(source, msg->map_epoch);
+  }
+  if (source.map_epoch != msg->map_epoch || source.awaiting_full_refresh) {
     RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
       "Waiting for a full refresh from %s", msg->source_id.c_str());
     return;
   }
-  if ((!msg->full_refresh && msg->version <= source.last_version) ||
-    (msg->full_refresh && !source.awaiting_full_refresh &&
-    msg->version < source.last_version))
-  {
+  if (msg->version <= source.last_version) {
     return;
   }
 
-  if (msg->full_refresh) {
-    reset_remote_source(source, msg->map_epoch);
-  }
+  apply_voxel_delta(source, *msg);
+  updated_map_once_ = updated_map_once_ || count > 0U;
+}
 
-  const double source_resolution = static_cast<double>(msg->resolution);
+void BonxaiServer::apply_voxel_delta(
+  RemoteSourceLayer & source, const surf_multirobot_msgs::msg::VoxelDelta & msg)
+{
+  const std::size_t count = msg.x.size();
+  const double source_resolution = static_cast<double>(msg.resolution);
   for (std::size_t index = 0; index < count; ++index) {
-    const uint8_t state = msg->state[index];
+    const uint8_t state = msg.state[index];
     if (state < surf_multirobot_msgs::msg::VoxelDelta::STATE_OCCUPIED_STATIC ||
       state > surf_multirobot_msgs::msg::VoxelDelta::STATE_DELETE)
     {
@@ -351,13 +399,13 @@ void BonxaiServer::voxel_delta_callback(
     // Expand a coarse source voxel over every local Bonxai voxel it covers.
     // nextafter keeps the upper face in the half-open source cell.
     const Eigen::Vector3d lower(
-      static_cast<double>(msg->x[index]) * source_resolution,
-      static_cast<double>(msg->y[index]) * source_resolution,
-      static_cast<double>(msg->z[index]) * source_resolution);
+      static_cast<double>(msg.x[index]) * source_resolution,
+      static_cast<double>(msg.y[index]) * source_resolution,
+      static_cast<double>(msg.z[index]) * source_resolution);
     const Eigen::Vector3d upper(
-      (static_cast<double>(msg->x[index]) + 1.0) * source_resolution,
-      (static_cast<double>(msg->y[index]) + 1.0) * source_resolution,
-      (static_cast<double>(msg->z[index]) + 1.0) * source_resolution);
+      (static_cast<double>(msg.x[index]) + 1.0) * source_resolution,
+      (static_cast<double>(msg.y[index]) + 1.0) * source_resolution,
+      (static_cast<double>(msg.z[index]) + 1.0) * source_resolution);
     const Eigen::Vector3d upper_inside(
       std::nextafter(upper.x(), lower.x()),
       std::nextafter(upper.y(), lower.y()),
@@ -376,7 +424,7 @@ void BonxaiServer::voxel_delta_callback(
     {
       RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
         "Rejected voxel requiring excessive resolution expansion from %s",
-        msg->source_id.c_str());
+        msg.source_id.c_str());
       continue;
     }
 
@@ -411,10 +459,9 @@ void BonxaiServer::voxel_delta_callback(
   }
 
   source.occupancy->updateFreeCellsPreRayTrace();
-  source.map_epoch = msg->map_epoch;
-  source.last_version = msg->version;
+  source.map_epoch = msg.map_epoch;
+  source.last_version = msg.version;
   source.awaiting_full_refresh = false;
-  updated_map_once_ = updated_map_once_ || count > 0U;
 }
 
 void BonxaiServer::reset_remote_source(RemoteSourceLayer & source, uint64_t map_epoch)
@@ -446,6 +493,7 @@ void BonxaiServer::get_fused_occupied_voxels(
     }
   }
 
+  std::lock_guard<std::mutex> lock(remote_sources_mutex_);
   for (const auto & [source_id, source] : remote_sources_) {
     (void)source_id;
     if (!source.occupancy || source.awaiting_full_refresh) {
@@ -471,14 +519,17 @@ void BonxaiServer::get_fused_free_voxels(std::vector<Bonxai::CoordT> & coords) c
     occupancy_map_->getFreeVoxels(local_free);
     unique_coords.insert(local_free.begin(), local_free.end());
   }
-  for (const auto & [source_id, source] : remote_sources_) {
-    (void)source_id;
-    if (!source.occupancy || source.awaiting_full_refresh) {
-      continue;
+  {
+    std::lock_guard<std::mutex> lock(remote_sources_mutex_);
+    for (const auto & [source_id, source] : remote_sources_) {
+      (void)source_id;
+      if (!source.occupancy || source.awaiting_full_refresh) {
+        continue;
+      }
+      std::vector<Bonxai::CoordT> remote_free;
+      source.occupancy->getFreeVoxels(remote_free);
+      unique_coords.insert(remote_free.begin(), remote_free.end());
     }
-    std::vector<Bonxai::CoordT> remote_free;
-    source.occupancy->getFreeVoxels(remote_free);
-    unique_coords.insert(remote_free.begin(), remote_free.end());
   }
 
   std::vector<Bonxai::CoordT> occupied;

--- a/bonxai_ros/src/bonxai_server.cpp
+++ b/bonxai_ros/src/bonxai_server.cpp
@@ -82,6 +82,8 @@ void BonxaiServer::load_parameters()
     
   params_.topic_in =
     this->declare_parameter<std::string>("topic_in", "/points");
+  params_.delta_topic_in =
+    this->declare_parameter<std::string>("delta_topic_in", "");
 
   params_.static_resolution =
     this->declare_parameter<double>("occupancy.static_resolution", 0.05);
@@ -127,6 +129,9 @@ void BonxaiServer::load_parameters()
     this->declare_parameter<bool>("stats.quick_stats", true);
 
   params_.publish_occupied_voxels = this->declare_parameter<bool>("stats.publish_occupied_voxels",true);
+
+  params_.stats_publish_rate =
+    this->declare_parameter<double>("stats.publish_rate", 1.0);
     
   params_.static_voxel_publish_rate =
     this->declare_parameter<double>("stats.static_publish_rate", 1.0);
@@ -153,7 +158,7 @@ void BonxaiServer::load_parameters()
   params_.static_map_load_on_startup =
     this->declare_parameter<bool>("map_storage.load_on_startup", false);
   params_.static_map_save_on_shutdown =
-    this->declare_parameter<bool>("map_storage.save_on_shutdown", false);
+    this->declare_parameter<bool>("map_storage.save_on_shutdown", true);
 
   RCLCPP_INFO(get_logger(),
     "Bonxai params loaded:"
@@ -165,7 +170,7 @@ void BonxaiServer::load_parameters()
     "\n  occupancy_thresh=%.2f"
     "\n  sensor(hit=%.2f miss=%.2f min=%.2f max=%.2f range=%.2f)"
     "\n  cleanup_interval=%.1fs"
-    "\n  stats(enabled=%s quick=%s voxels=%s static_rate=%.1fHz dynamic_rate=%.1fHz)"
+    "\n  stats(enabled=%s quick=%s voxels=%s stats_rate=%.1fHz static_rate=%.1fHz dynamic_rate=%.1fHz)"
     "\n  dynamic_obstacles(enabled=%s dynamic_decay=%.2fs interval=%.2fs static_demotion=%.2fs stability_hits=%d stability_window=%.2fs)",
     params_.static_resolution,
     params_.dynamic_resolution,
@@ -184,6 +189,7 @@ void BonxaiServer::load_parameters()
     params_.enable_stats ? "true" : "false",
     params_.quick_stats ? "true" : "false",
     params_.publish_occupied_voxels ? "true" : "false",
+    params_.stats_publish_rate,
     params_.static_voxel_publish_rate,
     params_.dynamic_voxel_publish_rate,
     params_.dynamic_obstacles_enabled ? "true" : "false",
@@ -211,19 +217,19 @@ void BonxaiServer::init_publishers()
   // Create stats publisher if enabled
   if (params_.enable_stats) {
     stats_publisher_ = this->create_publisher<bonxai_msgs::msg::OccupancyMapStats>(
-      "/bonxai/occupancy_stats",
+      "bonxai/occupancy_stats",
       rclcpp::QoS(10));
     
     if (params_.publish_occupied_voxels) {
       occupied_voxel_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
-        "/bonxai/occupied_voxels", rclcpp::QoS(10));
+        "bonxai/occupied_voxels", rclcpp::QoS(10));
       static_voxel_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
-        "/bonxai/static_occupied_voxels", rclcpp::QoS(10));
+        "bonxai/static_occupied_voxels", rclcpp::QoS(10));
       dynamic_voxel_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
-        "/bonxai/dynamic_occupied_voxels", rclcpp::QoS(10));
+        "bonxai/dynamic_occupied_voxels", rclcpp::QoS(10));
     }
   
-    RCLCPP_INFO(get_logger(), "Stats publisher created: /bonxai/occupancy_stats");
+    RCLCPP_INFO(get_logger(), "Stats publisher created: bonxai/occupancy_stats");
   }
 }
 
@@ -238,6 +244,15 @@ void BonxaiServer::init_subscribers()
     std::bind(&BonxaiServer::pointcloud_callback, this, std::placeholders::_1));
   
   RCLCPP_INFO(get_logger(), "Subscribed to: %s", params_.topic_in.c_str());
+
+  if (!params_.delta_topic_in.empty()) {
+    delta_sub_ = this->create_subscription<surf_multirobot_msgs::msg::VoxelDelta>(
+      params_.delta_topic_in,
+      rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile(),
+      std::bind(&BonxaiServer::voxel_delta_callback, this, std::placeholders::_1));
+    RCLCPP_INFO(get_logger(), "Subscribed to remote voxel deltas: %s",
+      params_.delta_topic_in.c_str());
+  }
 }
 
 void BonxaiServer::init_services()
@@ -246,29 +261,232 @@ void BonxaiServer::init_services()
   
   // Create service servers
   occupied_voxels_service_ = this->create_service<bonxai_msgs::srv::GetOccupiedVoxels>(
-    "/bonxai/get_occupied_voxels",
+    "bonxai/get_occupied_voxels",
     std::bind(&BonxaiServer::handle_get_occupied_voxels, this,
               std::placeholders::_1, std::placeholders::_2));
               
   free_voxels_service_ = this->create_service<bonxai_msgs::srv::GetFreeVoxels>(
-    "/bonxai/get_free_voxels",
+    "bonxai/get_free_voxels",
     std::bind(&BonxaiServer::handle_get_free_voxels, this,
               std::placeholders::_1, std::placeholders::_2));
 
   save_static_map_service_ = this->create_service<std_srvs::srv::Trigger>(
-    "/bonxai/save_static_map",
+    "bonxai/save_static_map",
     std::bind(&BonxaiServer::handle_save_static_map, this,
               std::placeholders::_1, std::placeholders::_2));
   load_static_map_service_ = this->create_service<std_srvs::srv::Trigger>(
-    "/bonxai/load_static_map",
+    "bonxai/load_static_map",
     std::bind(&BonxaiServer::handle_load_static_map, this,
               std::placeholders::_1, std::placeholders::_2));
   
   RCLCPP_INFO(get_logger(), "Services created:");
-  RCLCPP_INFO(get_logger(), "  - /bonxai/get_occupied_voxels");
-  RCLCPP_INFO(get_logger(), "  - /bonxai/get_free_voxels");
-  RCLCPP_INFO(get_logger(), "  - /bonxai/save_static_map");
-  RCLCPP_INFO(get_logger(), "  - /bonxai/load_static_map");
+  RCLCPP_INFO(get_logger(), "  - bonxai/get_occupied_voxels");
+  RCLCPP_INFO(get_logger(), "  - bonxai/get_free_voxels");
+  RCLCPP_INFO(get_logger(), "  - bonxai/save_static_map");
+  RCLCPP_INFO(get_logger(), "  - bonxai/load_static_map");
+}
+
+void BonxaiServer::voxel_delta_callback(
+  const surf_multirobot_msgs::msg::VoxelDelta::SharedPtr msg)
+{
+  const std::size_t count = msg->x.size();
+  if (!occupancy_map_ || !dynamic_obstacle_map_) {
+    return;
+  }
+  if (msg->source_id.empty()) {
+    RCLCPP_WARN(get_logger(), "Rejected voxel delta without a source ID");
+    return;
+  }
+  if (msg->header.frame_id != params_.frame_id) {
+    RCLCPP_WARN(get_logger(), "Rejected delta in frame '%s'; expected '%s'",
+      msg->header.frame_id.c_str(), params_.frame_id.c_str());
+    return;
+  }
+  if (!std::isfinite(msg->resolution) || msg->resolution <= 0.0 ||
+    msg->y.size() != count || msg->z.size() != count ||
+    msg->state.size() != count)
+  {
+    RCLCPP_WARN(get_logger(), "Rejected malformed voxel delta from %s",
+      msg->source_id.c_str());
+    return;
+  }
+
+  auto & source = remote_sources_[msg->source_id];
+  const bool epoch_changed = source.occupancy && source.map_epoch != msg->map_epoch;
+  if (!source.occupancy || epoch_changed) {
+    if (epoch_changed) {
+      RCLCPP_WARN(get_logger(), "Map epoch changed for %s; discarding its old remote layer",
+        msg->source_id.c_str());
+    }
+    reset_remote_source(source, msg->map_epoch);
+  }
+
+  if (source.awaiting_full_refresh && !msg->full_refresh) {
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
+      "Waiting for a full refresh from %s", msg->source_id.c_str());
+    return;
+  }
+  if ((!msg->full_refresh && msg->version <= source.last_version) ||
+    (msg->full_refresh && !source.awaiting_full_refresh &&
+    msg->version < source.last_version))
+  {
+    return;
+  }
+
+  if (msg->full_refresh) {
+    reset_remote_source(source, msg->map_epoch);
+  }
+
+  const double source_resolution = static_cast<double>(msg->resolution);
+  for (std::size_t index = 0; index < count; ++index) {
+    const uint8_t state = msg->state[index];
+    if (state < surf_multirobot_msgs::msg::VoxelDelta::STATE_OCCUPIED_STATIC ||
+      state > surf_multirobot_msgs::msg::VoxelDelta::STATE_DELETE)
+    {
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
+        "Ignoring unknown voxel state %u", state);
+      continue;
+    }
+
+    // Expand a coarse source voxel over every local Bonxai voxel it covers.
+    // nextafter keeps the upper face in the half-open source cell.
+    const Eigen::Vector3d lower(
+      static_cast<double>(msg->x[index]) * source_resolution,
+      static_cast<double>(msg->y[index]) * source_resolution,
+      static_cast<double>(msg->z[index]) * source_resolution);
+    const Eigen::Vector3d upper(
+      (static_cast<double>(msg->x[index]) + 1.0) * source_resolution,
+      (static_cast<double>(msg->y[index]) + 1.0) * source_resolution,
+      (static_cast<double>(msg->z[index]) + 1.0) * source_resolution);
+    const Eigen::Vector3d upper_inside(
+      std::nextafter(upper.x(), lower.x()),
+      std::nextafter(upper.y(), lower.y()),
+      std::nextafter(upper.z(), lower.z()));
+    const auto minimum = source.occupancy->worldToVoxel(lower);
+    const auto maximum = source.occupancy->worldToVoxel(upper_inside);
+    const int64_t cells_x = static_cast<int64_t>(maximum.x) - minimum.x + 1;
+    const int64_t cells_y = static_cast<int64_t>(maximum.y) - minimum.y + 1;
+    const int64_t cells_z = static_cast<int64_t>(maximum.z) - minimum.z + 1;
+    constexpr int64_t kMaximumExpandedCells = 4096;
+    if (cells_x <= 0 || cells_y <= 0 || cells_z <= 0 ||
+      cells_x > kMaximumExpandedCells || cells_y > kMaximumExpandedCells ||
+      cells_z > kMaximumExpandedCells ||
+      cells_x * cells_y > kMaximumExpandedCells ||
+      cells_x * cells_y * cells_z > kMaximumExpandedCells)
+    {
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
+        "Rejected voxel requiring excessive resolution expansion from %s",
+        msg->source_id.c_str());
+      continue;
+    }
+
+    for (int64_t x = minimum.x; x <= maximum.x; ++x) {
+      for (int64_t y = minimum.y; y <= maximum.y; ++y) {
+        for (int64_t z = minimum.z; z <= maximum.z; ++z) {
+          const Bonxai::CoordT coord{
+            static_cast<int32_t>(x), static_cast<int32_t>(y), static_cast<int32_t>(z)};
+          source.occupancy->resetPoint(coord);
+          switch (state) {
+            case surf_multirobot_msgs::msg::VoxelDelta::STATE_OCCUPIED_STATIC:
+              source.occupancy->addHitPoint(coord);
+              source.dynamic_voxels.erase(coord);
+              break;
+            case surf_multirobot_msgs::msg::VoxelDelta::STATE_OCCUPIED_DYNAMIC:
+              source.occupancy->addHitPoint(coord);
+              source.dynamic_voxels.insert(coord);
+              break;
+            case surf_multirobot_msgs::msg::VoxelDelta::STATE_FREE:
+              source.occupancy->addMissPoint(coord);
+              source.dynamic_voxels.erase(coord);
+              break;
+            case surf_multirobot_msgs::msg::VoxelDelta::STATE_DELETE:
+              source.dynamic_voxels.erase(coord);
+              break;
+            default:
+              break;
+          }
+        }
+      }
+    }
+  }
+
+  source.occupancy->updateFreeCellsPreRayTrace();
+  source.map_epoch = msg->map_epoch;
+  source.last_version = msg->version;
+  source.awaiting_full_refresh = false;
+  updated_map_once_ = updated_map_once_ || count > 0U;
+}
+
+void BonxaiServer::reset_remote_source(RemoteSourceLayer & source, uint64_t map_epoch)
+{
+  source.map_epoch = map_epoch;
+  source.last_version = 0U;
+  source.awaiting_full_refresh = true;
+  source.occupancy = std::make_unique<Bonxai::OccupancyMap>(
+    params_.static_resolution, occupancy_map_->getOptions());
+  source.dynamic_voxels.clear();
+}
+
+void BonxaiServer::get_fused_occupied_voxels(
+  std::vector<Bonxai::CoordT> & coords, bool include_static, bool include_dynamic) const
+{
+  std::set<Bonxai::CoordT> unique_coords;
+  if (include_static && occupancy_map_) {
+    std::vector<Bonxai::CoordT> local_static;
+    occupancy_map_->getOccupiedVoxels(local_static);
+    unique_coords.insert(local_static.begin(), local_static.end());
+  }
+  if (include_dynamic && dynamic_obstacle_map_) {
+    std::vector<Bonxai::CoordT> local_dynamic;
+    get_dynamic_obstacle_voxels(local_dynamic);
+    for (const auto & coord : local_dynamic) {
+      const auto position = dynamic_obstacle_map_->getGrid().coordToPos(coord);
+      unique_coords.insert(occupancy_map_->worldToVoxel(
+        Eigen::Vector3d(position.x, position.y, position.z)));
+    }
+  }
+
+  for (const auto & [source_id, source] : remote_sources_) {
+    (void)source_id;
+    if (!source.occupancy || source.awaiting_full_refresh) {
+      continue;
+    }
+    std::vector<Bonxai::CoordT> remote_occupied;
+    source.occupancy->getOccupiedVoxels(remote_occupied);
+    for (const auto & coord : remote_occupied) {
+      const bool dynamic = source.dynamic_voxels.find(coord) != source.dynamic_voxels.end();
+      if ((dynamic && include_dynamic) || (!dynamic && include_static)) {
+        unique_coords.insert(coord);
+      }
+    }
+  }
+  coords.assign(unique_coords.begin(), unique_coords.end());
+}
+
+void BonxaiServer::get_fused_free_voxels(std::vector<Bonxai::CoordT> & coords) const
+{
+  std::set<Bonxai::CoordT> unique_coords;
+  if (occupancy_map_) {
+    std::vector<Bonxai::CoordT> local_free;
+    occupancy_map_->getFreeVoxels(local_free);
+    unique_coords.insert(local_free.begin(), local_free.end());
+  }
+  for (const auto & [source_id, source] : remote_sources_) {
+    (void)source_id;
+    if (!source.occupancy || source.awaiting_full_refresh) {
+      continue;
+    }
+    std::vector<Bonxai::CoordT> remote_free;
+    source.occupancy->getFreeVoxels(remote_free);
+    unique_coords.insert(remote_free.begin(), remote_free.end());
+  }
+
+  std::vector<Bonxai::CoordT> occupied;
+  get_fused_occupied_voxels(occupied, true, true);
+  for (const auto & coord : occupied) {
+    unique_coords.erase(coord);
+  }
+  coords.assign(unique_coords.begin(), unique_coords.end());
 }
 
 void BonxaiServer::init_timers()
@@ -283,14 +501,14 @@ void BonxaiServer::init_timers()
   RCLCPP_INFO(get_logger(), "Cleanup timer started: every %.1fs", params_.cleanup_interval_sec);
   
   // Start stats timer if enabled
-  if (params_.enable_stats && stats_publisher_ && params_.dynamic_voxel_publish_rate > 0.0) {
+  if (params_.enable_stats && stats_publisher_ && params_.stats_publish_rate > 0.0) {
     stats_timer_ = this->create_wall_timer(
-      std::chrono::duration<double>(1.0 / params_.dynamic_voxel_publish_rate),
+      std::chrono::duration<double>(1.0 / params_.stats_publish_rate),
       std::bind(&BonxaiServer::stats_timer_callback, this));
     
     RCLCPP_INFO(get_logger(), 
       "Stats publishing enabled: rate=%.1f Hz, quick=%s",
-      params_.dynamic_voxel_publish_rate,
+      params_.stats_publish_rate,
       params_.quick_stats ? "true" : "false");
   }
 
@@ -674,31 +892,19 @@ void BonxaiServer::handle_get_occupied_voxels(
   
   auto start = std::chrono::steady_clock::now();
   
-  // Get occupied voxels from the static layer plus the dynamic layer.
   std::vector<Bonxai::CoordT> coords;
-  occupancy_map_->getOccupiedVoxels(coords);
-
-  if (params_.dynamic_obstacles_enabled && dynamic_obstacle_map_) {
-    std::vector<Bonxai::CoordT> dynamic_coords;
-    get_dynamic_obstacle_voxels(dynamic_coords);
-    std::set<Bonxai::CoordT> unique_coords(coords.begin(), coords.end());
-    for (const auto& coord : dynamic_coords) {
-      const auto position = dynamic_obstacle_map_->getGrid().coordToPos(coord);
-      unique_coords.insert(occupancy_map_->worldToVoxel(
-        Eigen::Vector3d(position.x, position.y, position.z)));
-    }
-    coords.assign(unique_coords.begin(), unique_coords.end());
-  }
+  get_fused_occupied_voxels(coords, true, params_.dynamic_obstacles_enabled);
   
   // Fill response
   fill_voxel_grid_msg(coords, response->voxel_grid);
   
   // Get statistics
   auto stats = occupancy_map_->getQuickStats();
-  response->occupied_count = stats.occupied_cells;
+  response->occupied_count = coords.size();
   response->total_active_cells = stats.total_active_cells;
   response->occupancy_ratio = stats.occupancy_ratio;
   response->memory_mb = static_cast<float>(stats.total_memory_bytes) / 1048576.0f;
+  response->success = true;
   
   auto end = std::chrono::steady_clock::now();
   auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
@@ -722,19 +928,19 @@ void BonxaiServer::handle_get_free_voxels(
   
   auto start = std::chrono::steady_clock::now();
   
-  // Get free voxels from the static layer.
   std::vector<Bonxai::CoordT> coords;
-  occupancy_map_->getFreeVoxels(coords);
+  get_fused_free_voxels(coords);
   
   // Fill response
   fill_voxel_grid_msg(coords, response->voxel_grid);
   
   // Get statistics
   auto stats = occupancy_map_->getQuickStats();
-  response->free_count = stats.free_cells;
+  response->free_count = coords.size();
   response->total_active_cells = stats.total_active_cells;
   response->occupancy_ratio = stats.occupancy_ratio;
   response->memory_mb = static_cast<float>(stats.total_memory_bytes) / 1048576.0f;
+  response->success = true;
   
   auto end = std::chrono::steady_clock::now();
   auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
@@ -935,19 +1141,7 @@ void BonxaiServer::stats_timer_callback()
   
   sensor_msgs::msg::PointCloud2 pcl_msg;
   std::vector<Bonxai::CoordT> coords;
-  occupancy_map_->getOccupiedVoxels(coords);
-
-  if (params_.dynamic_obstacles_enabled && dynamic_obstacle_map_) {
-    std::vector<Bonxai::CoordT> dynamic_coords;
-    get_dynamic_obstacle_voxels(dynamic_coords);
-    std::set<Bonxai::CoordT> unique_coords(coords.begin(), coords.end());
-    for (const auto& coord : dynamic_coords) {
-      const auto position = dynamic_obstacle_map_->getGrid().coordToPos(coord);
-      unique_coords.insert(occupancy_map_->worldToVoxel(
-        Eigen::Vector3d(position.x, position.y, position.z)));
-    }
-    coords.assign(unique_coords.begin(), unique_coords.end());
-  }
+  get_fused_occupied_voxels(coords, true, params_.dynamic_obstacles_enabled);
 
   fill_pcl_msg(coords, pcl_msg, *occupancy_map_);
 
@@ -980,7 +1174,7 @@ void BonxaiServer::static_voxel_timer_callback()
   reconcile_dynamic_with_static_map();
 
   std::vector<Bonxai::CoordT> coords;
-  occupancy_map_->getOccupiedVoxels(coords);
+  get_fused_occupied_voxels(coords, true, false);
   sensor_msgs::msg::PointCloud2 message;
   fill_pcl_msg(coords, message, *occupancy_map_);
   static_voxel_publisher_->publish(message);
@@ -988,14 +1182,14 @@ void BonxaiServer::static_voxel_timer_callback()
 
 void BonxaiServer::dynamic_voxel_timer_callback()
 {
-  if (!dynamic_obstacle_map_ || !dynamic_voxel_publisher_) {
+  if (!occupancy_map_ || !dynamic_obstacle_map_ || !dynamic_voxel_publisher_) {
     return;
   }
 
   std::vector<Bonxai::CoordT> coords;
-  get_dynamic_obstacle_voxels(coords);
+  get_fused_occupied_voxels(coords, false, true);
   sensor_msgs::msg::PointCloud2 message;
-  fill_pcl_msg(coords, message, *dynamic_obstacle_map_);
+  fill_pcl_msg(coords, message, *occupancy_map_);
   dynamic_voxel_publisher_->publish(message);
 }
 

--- a/bonxai_ros/src/bonxai_server.cpp
+++ b/bonxai_ros/src/bonxai_server.cpp
@@ -225,7 +225,9 @@ void BonxaiServer::pointcloud_callback(const sensor_msgs::msg::PointCloud2::Shar
       params_.frame_id, //target frame: base_link 
       msg->header.frame_id, //frame where the camera is publshing at
       msg->header.stamp,
-      rclcpp::Duration::from_seconds(0.1));
+      // FAST-LIO publishes the transform for a scan after processing that
+      // scan, so allow enough time for the matching TF sample to arrive.
+      rclcpp::Duration::from_seconds(0.5));
   } catch (tf2::TransformException& ex) {
     RCLCPP_WARN(get_logger(), "Could not transform: %s", ex.what());
     return;

--- a/bonxai_ros/src/bonxai_server.cpp
+++ b/bonxai_ros/src/bonxai_server.cpp
@@ -3,6 +3,13 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <set>
+
+#include "bonxai_core/serialization.hpp"
+
 namespace Bonxai
 {
 
@@ -23,9 +30,18 @@ BonxaiServer::BonxaiServer(const rclcpp::NodeOptions& options)
   occ_options.clamp_max_log = Bonxai::Occupancy::logods(params_.sensor_max);
   occ_options.occupancy_threshold_log = Bonxai::Occupancy::logods(params_.occupancy_threshold);
   
-  occupancy_map_ = std::make_unique<Bonxai::OccupancyMap>(params_.resolution, occ_options);
+  occupancy_map_ = std::make_unique<Bonxai::OccupancyMap>(params_.static_resolution, occ_options);
+  dynamic_obstacle_map_ = std::make_unique<Bonxai::OccupancyMap>(params_.dynamic_resolution, occ_options);
+
+  if (params_.static_map_load_on_startup) {
+    std::string error_message;
+    if (!load_static_map(error_message)) {
+      RCLCPP_WARN(get_logger(), "Could not load startup static map: %s", error_message.c_str());
+    }
+  }
   
-  RCLCPP_INFO(get_logger(), "OccupancyMap created with resolution: %.3f", params_.resolution);
+  RCLCPP_INFO(get_logger(), "Occupancy maps created: static_resolution=%.3f dynamic_resolution=%.3f",
+    params_.static_resolution, params_.dynamic_resolution);
   
   // Initialize components
   init_publishers();
@@ -34,6 +50,22 @@ BonxaiServer::BonxaiServer(const rclcpp::NodeOptions& options)
   init_timers();
   
   RCLCPP_INFO(get_logger(), "BonxaiServer initialization complete!");
+}
+
+BonxaiServer::~BonxaiServer()
+{
+  if (!params_.static_map_save_on_shutdown) {
+    return;
+  }
+
+  std::string error_message;
+  if (save_static_map(error_message)) {
+    RCLCPP_INFO(get_logger(), "Saved static map during shutdown: %s",
+      params_.static_map_path.c_str());
+  } else {
+    RCLCPP_ERROR(get_logger(), "Failed to save static map during shutdown: %s",
+      error_message.c_str());
+  }
 }
 
 void BonxaiServer::load_parameters()
@@ -51,8 +83,10 @@ void BonxaiServer::load_parameters()
   params_.topic_in =
     this->declare_parameter<std::string>("topic_in", "/points");
 
-  params_.resolution =
-    this->declare_parameter<double>("occupancy.resolution", 0.05);
+  params_.static_resolution =
+    this->declare_parameter<double>("occupancy.static_resolution", 0.05);
+  params_.dynamic_resolution =
+    this->declare_parameter<double>("occupancy.dynamic_resolution", 0.05);
   
   // --- Occupancy z-bounds ---
   params_.occupancy_min_z =
@@ -94,21 +128,47 @@ void BonxaiServer::load_parameters()
 
   params_.publish_occupied_voxels = this->declare_parameter<bool>("stats.publish_occupied_voxels",true);
     
-  params_.stats_publish_rate =
-    this->declare_parameter<double>("stats.publish_rate", 1.0);
+  params_.static_voxel_publish_rate =
+    this->declare_parameter<double>("stats.static_publish_rate", 1.0);
+  params_.dynamic_voxel_publish_rate =
+    this->declare_parameter<double>("stats.dynamic_publish_rate", 5.0);
+
+  params_.dynamic_obstacles_enabled =
+    this->declare_parameter<bool>("dynamic_obstacles.enabled", true);
+  params_.dynamic_obstacle_decay_time_sec =
+    this->declare_parameter<double>("dynamic_obstacles.decay_time_sec", 2.0);
+  params_.dynamic_obstacle_decay_interval_sec =
+    this->declare_parameter<double>("dynamic_obstacles.decay_interval_sec", 0.25);
+  params_.dynamic_obstacle_static_demotion_time_sec =
+    this->declare_parameter<double>("dynamic_obstacles.static_demotion_time_sec", 20.0);
+  params_.dynamic_obstacle_static_stability_hits =
+    this->declare_parameter<int>("dynamic_obstacles.static_stability_hits", 3);
+  params_.dynamic_obstacle_static_stability_time_sec =
+    this->declare_parameter<double>("dynamic_obstacles.static_stability_time_sec", 1.0);
+  params_.dynamic_obstacle_min_probability =
+    this->declare_parameter<double>("dynamic_obstacles.min_probability", 0.05);
+
+  params_.static_map_path =
+    this->declare_parameter<std::string>("map_storage.path", "");
+  params_.static_map_load_on_startup =
+    this->declare_parameter<bool>("map_storage.load_on_startup", false);
+  params_.static_map_save_on_shutdown =
+    this->declare_parameter<bool>("map_storage.save_on_shutdown", false);
 
   RCLCPP_INFO(get_logger(),
     "Bonxai params loaded:"
-    "\n  resolution=%.3f"
+    "\n  static_resolution=%.3f dynamic_resolution=%.3f"
     "\n  frame_id=%s"
     "\n  base_frame_id=%s"
     "\n  topic_in=%s"
     "\n  occupancy_z=[%.2f, %.2f]"
-    "\n  occupancy_thresh = %.2f"
+    "\n  occupancy_thresh=%.2f"
     "\n  sensor(hit=%.2f miss=%.2f min=%.2f max=%.2f range=%.2f)"
     "\n  cleanup_interval=%.1fs"
-    "\n  stats(enabled=%s quick=%s voxels=%s rate=%.1fHz)",
-    params_.resolution,
+    "\n  stats(enabled=%s quick=%s voxels=%s static_rate=%.1fHz dynamic_rate=%.1fHz)"
+    "\n  dynamic_obstacles(enabled=%s dynamic_decay=%.2fs interval=%.2fs static_demotion=%.2fs stability_hits=%d stability_window=%.2fs)",
+    params_.static_resolution,
+    params_.dynamic_resolution,
     params_.frame_id.c_str(),
     params_.base_frame_id.c_str(),
     params_.topic_in.c_str(),
@@ -124,7 +184,14 @@ void BonxaiServer::load_parameters()
     params_.enable_stats ? "true" : "false",
     params_.quick_stats ? "true" : "false",
     params_.publish_occupied_voxels ? "true" : "false",
-    params_.stats_publish_rate);
+    params_.static_voxel_publish_rate,
+    params_.dynamic_voxel_publish_rate,
+    params_.dynamic_obstacles_enabled ? "true" : "false",
+    params_.dynamic_obstacle_decay_time_sec,
+    params_.dynamic_obstacle_decay_interval_sec,
+    params_.dynamic_obstacle_static_demotion_time_sec,
+    params_.dynamic_obstacle_static_stability_hits,
+    params_.dynamic_obstacle_static_stability_time_sec);
 }
 
 void BonxaiServer::init_tf()
@@ -147,8 +214,14 @@ void BonxaiServer::init_publishers()
       "/bonxai/occupancy_stats",
       rclcpp::QoS(10));
     
-    occupied_voxel_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
-      "/bonxai/occupied_voxels",rclcpp::QoS(10));
+    if (params_.publish_occupied_voxels) {
+      occupied_voxel_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
+        "/bonxai/occupied_voxels", rclcpp::QoS(10));
+      static_voxel_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
+        "/bonxai/static_occupied_voxels", rclcpp::QoS(10));
+      dynamic_voxel_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
+        "/bonxai/dynamic_occupied_voxels", rclcpp::QoS(10));
+    }
   
     RCLCPP_INFO(get_logger(), "Stats publisher created: /bonxai/occupancy_stats");
   }
@@ -181,10 +254,21 @@ void BonxaiServer::init_services()
     "/bonxai/get_free_voxels",
     std::bind(&BonxaiServer::handle_get_free_voxels, this,
               std::placeholders::_1, std::placeholders::_2));
+
+  save_static_map_service_ = this->create_service<std_srvs::srv::Trigger>(
+    "/bonxai/save_static_map",
+    std::bind(&BonxaiServer::handle_save_static_map, this,
+              std::placeholders::_1, std::placeholders::_2));
+  load_static_map_service_ = this->create_service<std_srvs::srv::Trigger>(
+    "/bonxai/load_static_map",
+    std::bind(&BonxaiServer::handle_load_static_map, this,
+              std::placeholders::_1, std::placeholders::_2));
   
   RCLCPP_INFO(get_logger(), "Services created:");
   RCLCPP_INFO(get_logger(), "  - /bonxai/get_occupied_voxels");
   RCLCPP_INFO(get_logger(), "  - /bonxai/get_free_voxels");
+  RCLCPP_INFO(get_logger(), "  - /bonxai/save_static_map");
+  RCLCPP_INFO(get_logger(), "  - /bonxai/load_static_map");
 }
 
 void BonxaiServer::init_timers()
@@ -199,15 +283,42 @@ void BonxaiServer::init_timers()
   RCLCPP_INFO(get_logger(), "Cleanup timer started: every %.1fs", params_.cleanup_interval_sec);
   
   // Start stats timer if enabled
-  if (params_.enable_stats && stats_publisher_) {
+  if (params_.enable_stats && stats_publisher_ && params_.dynamic_voxel_publish_rate > 0.0) {
     stats_timer_ = this->create_wall_timer(
-      std::chrono::duration<double>(1.0 / params_.stats_publish_rate),
+      std::chrono::duration<double>(1.0 / params_.dynamic_voxel_publish_rate),
       std::bind(&BonxaiServer::stats_timer_callback, this));
     
     RCLCPP_INFO(get_logger(), 
       "Stats publishing enabled: rate=%.1f Hz, quick=%s",
-      params_.stats_publish_rate,
+      params_.dynamic_voxel_publish_rate,
       params_.quick_stats ? "true" : "false");
+  }
+
+  if (static_voxel_publisher_ && params_.static_voxel_publish_rate > 0.0) {
+    static_voxel_timer_ = this->create_wall_timer(
+      std::chrono::duration<double>(1.0 / params_.static_voxel_publish_rate),
+      std::bind(&BonxaiServer::static_voxel_timer_callback, this));
+    RCLCPP_INFO(get_logger(), "Static voxel publishing enabled: rate=%.1f Hz",
+      params_.static_voxel_publish_rate);
+  }
+
+  if (dynamic_voxel_publisher_ && params_.dynamic_voxel_publish_rate > 0.0) {
+    dynamic_voxel_timer_ = this->create_wall_timer(
+      std::chrono::duration<double>(1.0 / params_.dynamic_voxel_publish_rate),
+      std::bind(&BonxaiServer::dynamic_voxel_timer_callback, this));
+    RCLCPP_INFO(get_logger(), "Dynamic voxel publishing enabled: rate=%.1f Hz",
+      params_.dynamic_voxel_publish_rate);
+  }
+
+  if (params_.dynamic_obstacles_enabled) {
+    dynamic_decay_timer_ = this->create_wall_timer(
+      std::chrono::duration<double>(params_.dynamic_obstacle_decay_interval_sec),
+      std::bind(&BonxaiServer::decay_dynamic_obstacles, this));
+
+    RCLCPP_INFO(get_logger(),
+      "Dynamic obstacle decay enabled: decay=%.2fs interval=%.2fs",
+      params_.dynamic_obstacle_decay_time_sec,
+      params_.dynamic_obstacle_decay_interval_sec);
   }
 }
 
@@ -284,8 +395,13 @@ void BonxaiServer::pointcloud_callback(const sensor_msgs::msg::PointCloud2::Shar
     return;
   }
   
-  // Insert into occupancy map
-  occupancy_map_->insertPointCloud(map_points, sensor_origin, params_.sensor_max_range);
+  // Update static and dynamic occupancy layers
+  if (params_.dynamic_obstacles_enabled) {
+    update_dynamic_obstacle_layer(map_points, sensor_origin);
+  } else {
+    occupancy_map_->insertPointCloud(map_points, sensor_origin, params_.sensor_max_range);
+  }
+
   if (!updated_map_once_){
     updated_map_once_ = true;
   }
@@ -298,6 +414,250 @@ void BonxaiServer::pointcloud_callback(const sensor_msgs::msg::PointCloud2::Shar
     "Processed cloud: %zu points, %zu after filtering, origin: [%.2f, %.2f, %.2f]",
     cloud->size(), map_points.size(),
     sensor_origin.x(), sensor_origin.y(), sensor_origin.z());
+}
+
+void BonxaiServer::update_dynamic_obstacle_layer(
+  const std::vector<Eigen::Vector3d>& map_points,
+  const Eigen::Vector3d& sensor_origin)
+{
+  if (!dynamic_obstacle_map_) {
+    return;
+  }
+
+  dynamic_obstacle_map_->insertPointCloud(map_points, sensor_origin, params_.sensor_max_range);
+
+  const auto now = std::chrono::steady_clock::now();
+  std::set<Bonxai::CoordT> observed_voxels;
+  for (const auto& point : map_points) {
+    const auto coord = dynamic_obstacle_map_->worldToVoxel(point);
+    observed_voxels.insert(coord);
+  }
+
+  // Count at most one stability hit per voxel per cloud. Dense clouds often
+  // contain dozens of points in one voxel; counting points promoted an object
+  // to static during its very first scan.
+  for (const auto& coord : observed_voxels) {
+    const auto key = std::make_tuple(coord.x, coord.y, coord.z);
+    auto it = dynamic_obstacle_states_.find(key);
+
+    // The dynamic layer is the map delta: observations already represented
+    // by persistent static occupancy are background and are not transmitted.
+    if (dynamic_voxel_overlaps_static(coord)) {
+      if (it != dynamic_obstacle_states_.end()) {
+        if (it->second.promoted_to_static) {
+          it->second.last_seen = now;
+        } else {
+          dynamic_obstacle_states_.erase(it);
+        }
+      }
+      continue;
+    }
+
+    if (it == dynamic_obstacle_states_.end()) {
+      it = dynamic_obstacle_states_.emplace(key, DynamicCellState{}).first;
+    }
+
+    auto& state = it->second;
+    const double elapsed_seconds = std::chrono::duration<double>(now - state.last_seen).count();
+    if (elapsed_seconds > params_.dynamic_obstacle_static_stability_time_sec) {
+      state.consecutive_hits = 1;
+    } else {
+      ++state.consecutive_hits;
+    }
+    state.last_seen = now;
+
+    if (!state.promoted_to_static &&
+        state.consecutive_hits >= static_cast<uint32_t>(params_.dynamic_obstacle_static_stability_hits)) {
+      state.promoted_static_coord = dynamic_to_static_coord(coord);
+      occupancy_map_->addHitPoint(state.promoted_static_coord);
+      state.promoted_to_static = true;
+    }
+  }
+}
+
+Bonxai::CoordT BonxaiServer::dynamic_to_static_coord(const Bonxai::CoordT& coord) const
+{
+  const auto position = dynamic_obstacle_map_->getGrid().coordToPos(coord);
+  return occupancy_map_->worldToVoxel(Eigen::Vector3d(position.x, position.y, position.z));
+}
+
+bool BonxaiServer::dynamic_voxel_overlaps_static(const Bonxai::CoordT& coord) const
+{
+  return occupancy_map_ && dynamic_obstacle_map_ &&
+    occupancy_map_->isOccupied(dynamic_to_static_coord(coord));
+}
+
+void BonxaiServer::reconcile_dynamic_with_static_map()
+{
+  for (auto it = dynamic_obstacle_states_.begin(); it != dynamic_obstacle_states_.end();) {
+    if (it->second.promoted_to_static) {
+      ++it;
+      continue;
+    }
+
+    const auto& key = it->first;
+    const Bonxai::CoordT dynamic_coord{
+      std::get<0>(key), std::get<1>(key), std::get<2>(key)};
+    if (dynamic_voxel_overlaps_static(dynamic_coord)) {
+      it = dynamic_obstacle_states_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+void BonxaiServer::get_dynamic_obstacle_voxels(std::vector<Bonxai::CoordT>& coords) const
+{
+  coords.clear();
+  coords.reserve(dynamic_obstacle_states_.size());
+  for (const auto& [key, state] : dynamic_obstacle_states_) {
+    if (!state.promoted_to_static) {
+      coords.push_back(Bonxai::CoordT{
+        std::get<0>(key), std::get<1>(key), std::get<2>(key)});
+    }
+  }
+}
+
+void BonxaiServer::decay_dynamic_obstacles()
+{
+  if (!dynamic_obstacle_map_ || !params_.dynamic_obstacles_enabled) {
+    return;
+  }
+
+  const auto now = std::chrono::steady_clock::now();
+  const double dt_seconds = params_.dynamic_obstacle_decay_interval_sec;
+  dynamic_obstacle_map_->applyTemporalDecay(dt_seconds, params_.dynamic_obstacle_decay_time_sec);
+
+  for (auto it = dynamic_obstacle_states_.begin(); it != dynamic_obstacle_states_.end();) {
+    const double age_seconds = std::chrono::duration<double>(now - it->second.last_seen).count();
+    const double expiration_seconds = it->second.promoted_to_static
+      ? params_.dynamic_obstacle_static_demotion_time_sec
+      : params_.dynamic_obstacle_decay_time_sec;
+    if (age_seconds > expiration_seconds) {
+      if (it->second.promoted_to_static) {
+        occupancy_map_->resetPoint(it->second.promoted_static_coord);
+      }
+      it = dynamic_obstacle_states_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+bool BonxaiServer::save_static_map(std::string& error_message) const
+{
+  if (params_.static_map_path.empty()) {
+    error_message = "map_storage.path is empty";
+    return false;
+  }
+  if (!occupancy_map_) {
+    error_message = "static occupancy map is not initialized";
+    return false;
+  }
+
+  try {
+    const std::filesystem::path map_path(params_.static_map_path);
+    if (map_path.has_parent_path()) {
+      std::filesystem::create_directories(map_path.parent_path());
+    }
+
+    const std::filesystem::path temporary_path = map_path.string() + ".tmp";
+    {
+      std::ofstream output(temporary_path, std::ios::binary | std::ios::trunc);
+      if (!output) {
+        error_message = "could not open temporary map file for writing: " + temporary_path.string();
+        return false;
+      }
+      Bonxai::Serialize(output, occupancy_map_->getGrid());
+      output.flush();
+      if (!output) {
+        error_message = "failed while writing static map: " + temporary_path.string();
+        return false;
+      }
+    }
+    std::filesystem::rename(temporary_path, map_path);
+
+    std::ofstream metadata(map_path.string() + ".yaml", std::ios::trunc);
+    if (metadata) {
+      metadata << "format: bonxai_static_map_v1\n"
+               << "map_file: " << map_path.filename().string() << "\n"
+               << "frame_id: " << params_.frame_id << "\n"
+               << "resolution: " << params_.static_resolution << "\n";
+    }
+    return true;
+  } catch (const std::exception& exception) {
+    error_message = exception.what();
+    return false;
+  }
+}
+
+bool BonxaiServer::load_static_map(std::string& error_message)
+{
+  if (params_.static_map_path.empty()) {
+    error_message = "map_storage.path is empty";
+    return false;
+  }
+  if (!occupancy_map_) {
+    error_message = "static occupancy map is not initialized";
+    return false;
+  }
+
+  try {
+    std::ifstream input(params_.static_map_path, std::ios::binary);
+    if (!input) {
+      error_message = "could not open static map: " + params_.static_map_path;
+      return false;
+    }
+
+    std::string header;
+    if (!std::getline(input, header)) {
+      error_message = "static map has no Bonxai header";
+      return false;
+    }
+    const auto header_info = Bonxai::GetHeaderInfo(header);
+    if (std::abs(header_info.resolution - params_.static_resolution) > 1.0e-9) {
+      error_message = "map resolution does not match occupancy.static_resolution";
+      return false;
+    }
+
+    auto grid = Bonxai::Deserialize<Bonxai::Occupancy::CellOcc>(input, header_info);
+    if (!input) {
+      error_message = "static map is truncated or unreadable";
+      return false;
+    }
+
+    const auto options = occupancy_map_->getOptions();
+    occupancy_map_ = std::make_unique<Bonxai::OccupancyMap>(options, std::move(grid));
+    dynamic_obstacle_map_ = std::make_unique<Bonxai::OccupancyMap>(params_.dynamic_resolution, options);
+    dynamic_obstacle_states_.clear();
+    updated_map_once_ = !occupancy_map_->getGrid().rootMap().empty();
+    return true;
+  } catch (const std::exception& exception) {
+    error_message = exception.what();
+    return false;
+  }
+}
+
+void BonxaiServer::handle_save_static_map(
+  const std::shared_ptr<std_srvs::srv::Trigger::Request>,
+  std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+{
+  std::string error_message;
+  response->success = save_static_map(error_message);
+  response->message = response->success
+    ? "Saved static map to " + params_.static_map_path
+    : error_message;
+}
+
+void BonxaiServer::handle_load_static_map(
+  const std::shared_ptr<std_srvs::srv::Trigger::Request>,
+  std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+{
+  std::string error_message;
+  response->success = load_static_map(error_message);
+  response->message = response->success
+    ? "Loaded static map from " + params_.static_map_path
+    : error_message;
 }
 
 void BonxaiServer::handle_get_occupied_voxels(
@@ -314,9 +674,21 @@ void BonxaiServer::handle_get_occupied_voxels(
   
   auto start = std::chrono::steady_clock::now();
   
-  // Get occupied voxels
+  // Get occupied voxels from the static layer plus the dynamic layer.
   std::vector<Bonxai::CoordT> coords;
   occupancy_map_->getOccupiedVoxels(coords);
+
+  if (params_.dynamic_obstacles_enabled && dynamic_obstacle_map_) {
+    std::vector<Bonxai::CoordT> dynamic_coords;
+    get_dynamic_obstacle_voxels(dynamic_coords);
+    std::set<Bonxai::CoordT> unique_coords(coords.begin(), coords.end());
+    for (const auto& coord : dynamic_coords) {
+      const auto position = dynamic_obstacle_map_->getGrid().coordToPos(coord);
+      unique_coords.insert(occupancy_map_->worldToVoxel(
+        Eigen::Vector3d(position.x, position.y, position.z)));
+    }
+    coords.assign(unique_coords.begin(), unique_coords.end());
+  }
   
   // Fill response
   fill_voxel_grid_msg(coords, response->voxel_grid);
@@ -350,7 +722,7 @@ void BonxaiServer::handle_get_free_voxels(
   
   auto start = std::chrono::steady_clock::now();
   
-  // Get free voxels
+  // Get free voxels from the static layer.
   std::vector<Bonxai::CoordT> coords;
   occupancy_map_->getFreeVoxels(coords);
   
@@ -378,7 +750,7 @@ void BonxaiServer::fill_voxel_grid_msg(
 {
   msg.header.stamp = this->now();
   msg.header.frame_id = params_.frame_id;
-  msg.resolution = params_.resolution;
+  msg.resolution = params_.static_resolution;
   msg.num_voxels = static_cast<uint32_t>(coords.size());
   
   if (coords.empty()) {
@@ -495,6 +867,9 @@ void BonxaiServer::cleanup_timer_callback()
   auto stats_before = occupancy_map_->getQuickStats();
   
   occupancy_map_->releaseUnusedMemory();
+  if (dynamic_obstacle_map_) {
+    dynamic_obstacle_map_->releaseUnusedMemory();
+  }
   
   auto stats_after = occupancy_map_->getQuickStats();
   
@@ -511,7 +886,8 @@ void BonxaiServer::cleanup_timer_callback()
 
 void BonxaiServer::fill_pcl_msg(
     const std::vector<Bonxai::CoordT>& coords,
-   sensor_msgs::msg::PointCloud2& pcl_msg)
+    sensor_msgs::msg::PointCloud2& pcl_msg,
+    const Bonxai::OccupancyMap& coordinate_map)
 {
   // Set up the point cloud message
   pcl_msg.header.stamp = this->now();
@@ -532,7 +908,7 @@ sensor_msgs::PointCloud2Iterator<uint8_t> iter_b(pcl_msg, "b");
 
   // Get grid for coordinate conversion
 
-  const auto &underlying_grid = occupancy_map_->getGrid();
+  const auto &underlying_grid = coordinate_map.getGrid();
   // Fill in the data
   for (const auto& coord : coords) {
       auto pos = underlying_grid.coordToPos(coord);
@@ -560,13 +936,29 @@ void BonxaiServer::stats_timer_callback()
   sensor_msgs::msg::PointCloud2 pcl_msg;
   std::vector<Bonxai::CoordT> coords;
   occupancy_map_->getOccupiedVoxels(coords);
-  fill_pcl_msg(coords,pcl_msg);
+
+  if (params_.dynamic_obstacles_enabled && dynamic_obstacle_map_) {
+    std::vector<Bonxai::CoordT> dynamic_coords;
+    get_dynamic_obstacle_voxels(dynamic_coords);
+    std::set<Bonxai::CoordT> unique_coords(coords.begin(), coords.end());
+    for (const auto& coord : dynamic_coords) {
+      const auto position = dynamic_obstacle_map_->getGrid().coordToPos(coord);
+      unique_coords.insert(occupancy_map_->worldToVoxel(
+        Eigen::Vector3d(position.x, position.y, position.z)));
+    }
+    coords.assign(unique_coords.begin(), unique_coords.end());
+  }
+
+  fill_pcl_msg(coords, pcl_msg, *occupancy_map_);
 
   bonxai_msgs::msg::OccupancyMapStats msg;
   fill_stats_msg(msg);
   
   stats_publisher_->publish(msg);
-  occupied_voxel_publisher_->publish(pcl_msg);
+
+  if (occupied_voxel_publisher_) {
+    occupied_voxel_publisher_->publish(pcl_msg);
+  }
 
   RCLCPP_INFO_STREAM(get_logger(),"Got " << coords.size() << "Occupied Voxels!");
   RCLCPP_INFO(get_logger(),
@@ -574,6 +966,37 @@ void BonxaiServer::stats_timer_callback()
     msg.total_active_cells,
     static_cast<double>(msg.total_memory_mib),
     msg.occupancy_ratio * 100.0f);
+}
+
+void BonxaiServer::static_voxel_timer_callback()
+{
+  if (!occupancy_map_ || !static_voxel_publisher_) {
+    return;
+  }
+
+  // Periodically perform a complete map/delta comparison. The per-scan path
+  // handles normal updates; this slower pass corrects accumulated mismatch
+  // after promotion, demotion, or loading/replacing a static map.
+  reconcile_dynamic_with_static_map();
+
+  std::vector<Bonxai::CoordT> coords;
+  occupancy_map_->getOccupiedVoxels(coords);
+  sensor_msgs::msg::PointCloud2 message;
+  fill_pcl_msg(coords, message, *occupancy_map_);
+  static_voxel_publisher_->publish(message);
+}
+
+void BonxaiServer::dynamic_voxel_timer_callback()
+{
+  if (!dynamic_obstacle_map_ || !dynamic_voxel_publisher_) {
+    return;
+  }
+
+  std::vector<Bonxai::CoordT> coords;
+  get_dynamic_obstacle_voxels(coords);
+  sensor_msgs::msg::PointCloud2 message;
+  fill_pcl_msg(coords, message, *dynamic_obstacle_map_);
+  dynamic_voxel_publisher_->publish(message);
 }
 
 }  // namespace Bonxai


### PR DESCRIPTION
## What changed

- Added persistent static and transient dynamic Bonxai occupancy layers.
- Added temporal promotion, demotion, decay, and static-map delta filtering.
- Added independent static and dynamic resolutions and publication rates.
- Added native static-map save/load services and startup/shutdown persistence.
- Added focused occupancy-map regression coverage.

## Why

The mapping server previously accumulated moving obstacles in a single persistent map and could not publish or persist independently managed static and dynamic occupancy.

## Impact

Consumers can subscribe to separate static, dynamic, or combined voxel clouds. Dynamic output contains foreground deltas relative to the static map, while stable obstacles may still be promoted and later demoted.

## Validation

- `colcon build --packages-select bonxai_map bonxai_ros surf_multirobot_sim`
- `colcon test --packages-select bonxai_map bonxai_ros`
- 63 tests passed with no failures.
- `git diff --check`
